### PR TITLE
fix: navigate to heading on in-document anchor link clicks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "md-mini",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "md-mini",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",

--- a/src/lib/editor/heading-slugs.test.ts
+++ b/src/lib/editor/heading-slugs.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { languages } from '@codemirror/language-data';
+import { Strikethrough, Table } from '@lezer/markdown';
+import { slugify, headingSlugsField, getHeadingPos } from './heading-slugs';
+
+function makeState(doc: string): EditorState {
+  return EditorState.create({
+    doc,
+    extensions: [
+      markdown({
+        base: markdownLanguage,
+        codeLanguages: languages,
+        extensions: [Strikethrough, Table],
+      }),
+      headingSlugsField,
+    ],
+  });
+}
+
+describe('slugify', () => {
+  const cases: Array<[string, string]> = [
+    ['Hello, World!', 'hello-world'],
+    ['Установка приложения!', 'установка-приложения'],
+    ['Шаг 1: установка', 'шаг-1-установка'],
+    ['  leading and trailing  ', 'leading-and-trailing'],
+    ['multiple   spaces', 'multiple-spaces'],
+    ['kebab-already-here', 'kebab-already-here'],
+    ['emoji 🎉 stripped', 'emoji-stripped'],
+    ['a/b\\c.d:e', 'abcde'],
+    ['', ''],
+    ['!!!', ''],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`"${input}" → "${expected}"`, () => {
+      expect(slugify(input)).toBe(expected);
+    });
+  }
+});
+
+describe('headingSlugsField', () => {
+  it('indexes ATX headings by slug → line start position', () => {
+    const doc = '# Hello\n\nbody\n\n## Установка\n\nmore\n';
+    const state = makeState(doc);
+    expect(getHeadingPos(state, 'hello')).toBe(0);
+    expect(getHeadingPos(state, 'установка')).toBe(doc.indexOf('## Установка'));
+  });
+
+  it('returns null for unknown slug', () => {
+    const state = makeState('# A\n');
+    expect(getHeadingPos(state, 'nope')).toBeNull();
+  });
+
+  it('disambiguates duplicate slugs with -2, -3 suffixes', () => {
+    const doc = '## Шаг 1\n\nx\n\n## Шаг 1\n\ny\n\n## Шаг 1\n';
+    const state = makeState(doc);
+    const first = doc.indexOf('## Шаг 1');
+    const second = doc.indexOf('## Шаг 1', first + 1);
+    const third = doc.indexOf('## Шаг 1', second + 1);
+    expect(getHeadingPos(state, 'шаг-1')).toBe(first);
+    expect(getHeadingPos(state, 'шаг-1-2')).toBe(second);
+    expect(getHeadingPos(state, 'шаг-1-3')).toBe(third);
+  });
+
+  it('ignores empty headings (no slug)', () => {
+    const state = makeState('## \n\nbody\n');
+    expect(getHeadingPos(state, '')).toBeNull();
+  });
+
+  it('rebuilds on document change', () => {
+    const initial = makeState('# Old\n');
+    expect(getHeadingPos(initial, 'old')).toBe(0);
+    const tr = initial.update({ changes: { from: 0, to: initial.doc.length, insert: '# New\n' } });
+    const updated = tr.state;
+    expect(getHeadingPos(updated, 'new')).toBe(0);
+    expect(getHeadingPos(updated, 'old')).toBeNull();
+  });
+});

--- a/src/lib/editor/heading-slugs.test.ts
+++ b/src/lib/editor/heading-slugs.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { EditorState } from '@codemirror/state';
+import { describe, it, expect, vi } from 'vitest';
+import { EditorState, type Transaction } from '@codemirror/state';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
+import { codeFolding, foldEffect } from '@codemirror/language';
+import { EditorView } from '@codemirror/view';
 import { Strikethrough, Table } from '@lezer/markdown';
-import { slugify, headingSlugsField, getHeadingPos } from './heading-slugs';
+import { slugify, headingSlugsField, getHeadingPos, navigateToHeading } from './heading-slugs';
 
 function makeState(doc: string): EditorState {
   return EditorState.create({
@@ -31,6 +33,11 @@ describe('slugify', () => {
     ['a/b\\c.d:e', 'abcde'],
     ['', ''],
     ['!!!', ''],
+    // Leading/trailing dashes — both raw and produced by stripped punctuation
+    ['-edge-', 'edge'],
+    ['--foo--', 'foo'],
+    ['!Foo!', 'foo'],
+    ['Hello -- World', 'hello-world'],
   ];
 
   for (const [input, expected] of cases) {
@@ -76,5 +83,84 @@ describe('headingSlugsField', () => {
     const updated = tr.state;
     expect(getHeadingPos(updated, 'new')).toBe(0);
     expect(getHeadingPos(updated, 'old')).toBeNull();
+  });
+
+  it('does not index setext headings', () => {
+    const state = makeState('Foo\n===\n\nbody\n');
+    expect(getHeadingPos(state, 'foo')).toBeNull();
+  });
+});
+
+// Structural mock: navigateToHeading only touches view.state and view.dispatch,
+// so a real EditorView (which needs DOM) isn't required.
+function makeView(state: EditorState): {
+  view: EditorView;
+  calls: Array<{ effects: ReturnType<typeof EditorView.scrollIntoView>[] }>;
+} {
+  const calls: Array<{ effects: ReturnType<typeof EditorView.scrollIntoView>[] }> = [];
+  const view = {
+    state,
+    dispatch: vi.fn((spec: { effects?: unknown }) => {
+      const e = spec.effects;
+      const arr = Array.isArray(e) ? e : e !== undefined ? [e] : [];
+      calls.push({ effects: arr as ReturnType<typeof EditorView.scrollIntoView>[] });
+    }),
+  } as unknown as EditorView;
+  return { view, calls };
+}
+
+describe('navigateToHeading', () => {
+  it('dispatches a scrollIntoView effect for a known slug', () => {
+    const { view, calls } = makeView(makeState('# Hello\n\nbody\n'));
+    navigateToHeading(view, 'hello');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].effects.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('runs raw input through slugify (uppercase + URL-encoded)', () => {
+    const { view, calls } = makeView(makeState('# Установка\n\nbody\n'));
+    navigateToHeading(view, '%D0%A3%D1%81%D1%82%D0%B0%D0%BD%D0%BE%D0%B2%D0%BA%D0%B0');
+    expect(calls).toHaveLength(1);
+  });
+
+  it('is a silent no-op for unknown slug', () => {
+    const { view, calls } = makeView(makeState('# Hello\n'));
+    navigateToHeading(view, 'nope');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('is a silent no-op for empty fragment', () => {
+    const { view, calls } = makeView(makeState('# Hello\n'));
+    navigateToHeading(view, '');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('emits unfoldEffect when target heading is inside a folded range', () => {
+    // Build a state with codeFolding extension so foldEffect can take hold,
+    // and a multi-section doc so the first heading's fold contains a body line
+    // plus the next heading's slug position.
+    const doc = '# Top\n\nbody1\n\n## Inner\n\nbody2\n';
+    const startState = EditorState.create({
+      doc,
+      extensions: [
+        markdown({ base: markdownLanguage, codeLanguages: languages, extensions: [Strikethrough, Table] }),
+        codeFolding(),
+        headingSlugsField,
+      ],
+    });
+    // Fold "# Top" to swallow "## Inner" too — fold range starts after the
+    // first line and ends at end of doc.
+    const innerPos = doc.indexOf('## Inner');
+    const tr: Transaction = startState.update({
+      effects: foldEffect.of({ from: doc.indexOf('\n'), to: doc.length }),
+    });
+    const folded = tr.state;
+    const { view, calls } = makeView(folded);
+    navigateToHeading(view, 'inner');
+    expect(calls).toHaveLength(1);
+    // Should have both an unfold effect AND a scrollIntoView effect (2+ total)
+    expect(calls[0].effects.length).toBeGreaterThanOrEqual(2);
+    // sanity: index points at the heading we asked for
+    expect(getHeadingPos(folded, 'inner')).toBe(innerPos);
   });
 });

--- a/src/lib/editor/heading-slugs.ts
+++ b/src/lib/editor/heading-slugs.ts
@@ -1,0 +1,79 @@
+import { StateField, type EditorState, type StateEffect } from '@codemirror/state';
+import { syntaxTree } from '@codemirror/language';
+import { EditorView } from '@codemirror/view';
+import { foldedRanges, unfoldEffect } from '@codemirror/language';
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize('NFC')
+    .replace(/[^\p{L}\p{N}\s-]/gu, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+function buildIndex(state: EditorState): Map<string, number> {
+  const map = new Map<string, number>();
+  const counts = new Map<string, number>();
+  const tree = syntaxTree(state);
+  const doc = state.doc;
+
+  tree.iterate({
+    enter(node) {
+      const name = node.name;
+      if (!name.startsWith('ATXHeading') || name.length !== 11) return;
+
+      const headerMark = node.node.getChild('HeaderMark');
+      const textFrom = headerMark ? Math.min(headerMark.to + 1, node.to) : node.from;
+      const raw = doc.sliceString(textFrom, node.to);
+      const base = slugify(raw);
+      if (!base) return;
+
+      const n = counts.get(base) ?? 0;
+      counts.set(base, n + 1);
+      const slug = n === 0 ? base : `${base}-${n + 1}`;
+      if (!map.has(slug)) {
+        map.set(slug, doc.lineAt(node.from).from);
+      }
+    },
+  });
+
+  return map;
+}
+
+export const headingSlugsField = StateField.define<Map<string, number>>({
+  create: (state) => buildIndex(state),
+  update(value, tr) {
+    if (!tr.docChanged) return value;
+    return buildIndex(tr.state);
+  },
+});
+
+export function getHeadingPos(state: EditorState, slug: string): number | null {
+  const map = state.field(headingSlugsField, false);
+  if (!map) return null;
+  return map.get(slug) ?? null;
+}
+
+export function navigateToHeading(view: EditorView, rawSlug: string): boolean {
+  let slug: string;
+  try {
+    slug = decodeURIComponent(rawSlug);
+  } catch {
+    slug = rawSlug;
+  }
+  slug = slug.toLowerCase();
+
+  const pos = getHeadingPos(view.state, slug);
+  if (pos === null) return false;
+
+  const effects: StateEffect<unknown>[] = [];
+  const folded = foldedRanges(view.state);
+  folded.between(pos, pos + 1, (from, to) => {
+    effects.push(unfoldEffect.of({ from, to }));
+  });
+  effects.push(EditorView.scrollIntoView(pos, { y: 'start' }));
+  view.dispatch({ effects });
+  return true;
+}

--- a/src/lib/editor/heading-slugs.ts
+++ b/src/lib/editor/heading-slugs.ts
@@ -1,18 +1,19 @@
 import { StateField, type EditorState, type StateEffect } from '@codemirror/state';
-import { syntaxTree } from '@codemirror/language';
+import { syntaxTree, foldedRanges, unfoldEffect } from '@codemirror/language';
 import { EditorView } from '@codemirror/view';
-import { foldedRanges, unfoldEffect } from '@codemirror/language';
 
 export function slugify(text: string): string {
   return text
-    .toLowerCase()
     .normalize('NFC')
+    .toLowerCase()
     .replace(/[^\p{L}\p{N}\s-]/gu, '')
-    .trim()
     .replace(/\s+/g, '-')
-    .replace(/-+/g, '-');
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
+// Only ATX headings (`# Foo`) are indexed; setext (`Foo\n===`) is not — matches
+// the rest of the editor (folding.ts, preview/headings.ts) which is also ATX-only.
 function buildIndex(state: EditorState): Map<string, number> {
   const map = new Map<string, number>();
   const counts = new Map<string, number>();
@@ -56,17 +57,18 @@ export function getHeadingPos(state: EditorState, slug: string): number | null {
   return map.get(slug) ?? null;
 }
 
-export function navigateToHeading(view: EditorView, rawSlug: string): boolean {
-  let slug: string;
+export function navigateToHeading(view: EditorView, rawSlug: string): void {
+  let decoded: string;
   try {
-    slug = decodeURIComponent(rawSlug);
+    decoded = decodeURIComponent(rawSlug);
   } catch {
-    slug = rawSlug;
+    decoded = rawSlug;
   }
-  slug = slug.toLowerCase();
+  const slug = slugify(decoded);
+  if (!slug) return;
 
   const pos = getHeadingPos(view.state, slug);
-  if (pos === null) return false;
+  if (pos === null) return;
 
   const effects: StateEffect<unknown>[] = [];
   const folded = foldedRanges(view.state);
@@ -75,5 +77,4 @@ export function navigateToHeading(view: EditorView, rawSlug: string): boolean {
   });
   effects.push(EditorView.scrollIntoView(pos, { y: 'start' }));
   view.dispatch({ effects });
-  return true;
 }

--- a/src/lib/editor/setup.ts
+++ b/src/lib/editor/setup.ts
@@ -19,6 +19,7 @@ import { tableModeField } from './preview/table-state';
 import { tableSelectionSnapOut } from './preview/table-selection';
 import { hoverBlockMenu } from './hover-menu';
 import { markdownFoldService, headingFoldClick, headingFoldStatePlugin } from './folding';
+import { headingSlugsField, navigateToHeading } from './heading-slugs';
 
 export const previewCompartment = new Compartment();
 export const languageCompartment = new Compartment();
@@ -28,6 +29,7 @@ export function createExtensions(): Extension[] {
   return [
     editorTheme,
     tableModeField,
+    headingSlugsField,
     lineGlowCompartment.of([]),
     drawSelection(),
     listContinuation(),
@@ -105,6 +107,10 @@ export function createExtensions(): Extension[] {
         if (url) {
           event.preventDefault();
           event.stopPropagation();
+          if (url.startsWith('#')) {
+            navigateToHeading(view, url.slice(1));
+            return true;
+          }
           import('@tauri-apps/plugin-shell').then(({ open }) => {
             open(url);
           }).catch(() => {

--- a/test-fixtures/toc-navigation.md
+++ b/test-fixtures/toc-navigation.md
@@ -1,0 +1,92 @@
+# Тестовый документ с TOC
+
+Документ для ручной проверки in-document anchor links.
+
+## Содержание
+
+- [Введение](#введение)
+- [Установка](#установка)
+- [Использование](#использование)
+- [Hello, World!](#hello-world)
+- [Шаг 1](#шаг-1)
+- [Шаг 1 (повтор)](#шаг-1-2)
+- [Шаг 1 (третий)](#шаг-1-3)
+- [External link to Google](https://google.com)
+- [Несуществующий якорь](#nonexistent)
+- [Заключение](#заключение)
+
+---
+
+## Введение
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+
+[← вернуться к содержанию](#содержание)
+
+## Установка
+
+Раздел про установку. Тут много текста чтобы заголовок ушёл за пределы экрана.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor.
+
+Ut in nulla enim. Phasellus molestie magna non est bibendum non venenatis nisl tempor. Suspendisse dictum feugiat nisl ut dapibus. Mauris iaculis porttitor posuere.
+
+Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue.
+
+[← вернуться к содержанию](#содержание)
+
+## Использование
+
+Раздел про использование. Дополнительный буфер текста.
+
+Donec venenatis vulputate lorem. Morbi nec metus. Phasellus blandit leo ut odio. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem.
+
+Sed magna purus, fermentum eu, tincidunt eu, varius ut, felis. In auctor lobortis lacus. Quisque libero metus, condimentum nec, tempor a, commodo mollis, magna.
+
+Vestibulum ullamcorper mauris at ligula. Fusce fermentum. Nullam cursus lacinia erat. Praesent blandit laoreet nibh. Fusce convallis metus id felis luctus adipiscing.
+
+[← вернуться к содержанию](#содержание)
+
+## Hello, World!
+
+Заголовок с пунктуацией. Slug должен быть `hello-world`.
+
+Lorem ipsum dolor sit amet. Aliquam erat volutpat. Nunc auctor. Mauris pretium quam et urna. Fusce nibh. Duis risus.
+
+[← вернуться к содержанию](#содержание)
+
+## Шаг 1
+
+Первый «Шаг 1».
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna.
+
+## Шаг 1
+
+Второй «Шаг 1» — должен быть доступен через `#шаг-1-2`.
+
+Nunc viverra imperdiet enim. Fusce est. Vivamus a tellus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+
+## Шаг 1
+
+Третий «Шаг 1» — `#шаг-1-3`.
+
+Proin pharetra nonummy pede. Mauris et orci. Aenean nec lorem. In porttitor. Donec laoreet nonummy augue.
+
+[← вернуться к содержанию](#содержание)
+
+## Заключение
+
+Последний раздел. Это далеко внизу — проверь что скролл реально прыгает к заголовку, а не куда попало.
+
+Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Mauris eget neque at sem venenatis eleifend. Ut nonummy.
+
+Fusce aliquet pede non pede. Suspendisse dapibus lorem pellentesque magna. Integer nulla. Donec blandit feugiat ligula. Donec hendrerit, felis et imperdiet euismod, purus ipsum pretium metus, in lacinia nulla nisl eget sapien.
+
+Donec ut est in lectus consequat consequat. Etiam eget dui. Aliquam erat volutpat. Sed at lorem in nunc porta tristique. Proin nec augue. Quisque aliquam tempor magna.
+
+[← вернуться к содержанию](#содержание)


### PR DESCRIPTION
## Summary

Clicks on TOC links like `[Section](#section)` did nothing useful — the mousedown handler in `src/lib/editor/setup.ts` unconditionally treated every URL as external and routed it through `shell.open`. On top of that, headings had no anchor target at all, only a CSS class for styling — so there was nowhere to scroll to even if the handler were fixed.

Both ends are now addressed:

- **`src/lib/editor/heading-slugs.ts`** (new) — `StateField<Map<string, number>>` mapping slug → start-of-line position, rebuilt on every `docChanged`. Slugify is GFM-style with Unicode (cyrillic, punctuation stripped, spaces → `-`, multiple `-` collapsed). Duplicate headings get `-2`, `-3` suffixes. Public helpers: `getHeadingPos(state, slug)` and `navigateToHeading(view, rawSlug)`.
- **`src/lib/editor/setup.ts`** — registers `headingSlugsField`; the `mousedown` handler now branches on `url.startsWith('#')` before falling through to `shell.open`.

`navigateToHeading` reuses the `foldedRanges` + `unfoldEffect` pattern already in `folding.ts` to expand a collapsed parent heading before scrolling, then dispatches `EditorView.scrollIntoView(pos, { y: 'start' })`. Selection is left alone — this is read-only navigation. Fragments are `decodeURIComponent`-ed and lowercased before lookup, so percent-encoded TOC links (`#%D1%83%D1%81%D1%82%D0%B0%D0%BD%D0%BE%D0%B2%D0%BA%D0%B0`) work. Unknown slugs are a silent no-op (preventDefault + nothing else — `shell.open('#foo')` would just shove garbage at the OS).

Behaviour explicitly **not** changed:
- External links (`http://…`, `mailto:`, etc.) still go through `shell.open` as before.
- Relative links to other `.md` files are out of scope.
- Heading DOM stays unchanged — slug index lives in editor state, not as DOM attributes.

Closes #1.

## Test plan

- [x] **Unit tests** — `src/lib/editor/heading-slugs.test.ts` (15 cases). Covers `slugify` table (ASCII, cyrillic, punctuation, leading/trailing whitespace, multiple spaces, emoji stripping, empty result), index build via `EditorState.create`, missing-slug → null, duplicate disambiguation (`шаг-1`, `шаг-1-2`, `шаг-1-3` pointing at three different positions), rebuild on `docChanged`. Full suite: 82/82 pass (`npx vitest run`).
- [x] **Type-check** — `npm run check` is clean on the new files. (Two pre-existing `MenuAction` errors in `App.svelte` are untouched and unrelated.)
- [x] **Manual UI verification** — opened `test-fixtures/toc-navigation.md` in `npm run dev:app` via Tauri MCP Bridge. Confirmed: clicking "Заключение" scrolls to the last heading; clicking "Шаг 1 (повтор)" lands precisely on the second of three "Шаг 1" headings (text "Второй «Шаг 1» — должен быть доступен через #шаг-1-2" was visible at viewport top after the click); TOC renders correctly with cyrillic + ASCII + punctuation + duplicates.
- [ ] **Folded-heading case** — programmatic test exists (index update on docChanged), but visual unfold-before-scroll path wasn't toggled by hand. Reviewers might want to click the fold gutter on "Введение" and then click "[Введение](#введение)" in TOC to confirm.
- [ ] **External links** — code path unchanged, but a quick sanity click on `[External link to Google](https://google.com)` in the fixture is worth doing during review.

`test-fixtures/toc-navigation.md` is included as a living fixture for this case — useful for any future regression checks around link handling.

## Notes for reviewer

- `chore: sync package-lock.json to package.json v0.3.2` is a separate commit. The lockfile was pinned to the older version and `npm install` rewrites it on every checkout. Including it stops the file from showing up dirty after dependency install.