### PR TITLE
fix(tables): render markdown links inside table cells

### DIFF
--- a/src/lib/editor/preview/tables.test.ts
+++ b/src/lib/editor/preview/tables.test.ts
@@ -1,7 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { languages } from '@codemirror/language-data';
+import { Strikethrough, Table } from '@lezer/markdown';
+import { EditorView } from '@codemirror/view';
+import { headingSlugsField } from '../heading-slugs';
 import {
   parseCellsWithPositions,
   parseInlineMarkdown,
+  routeLinkClick,
   tableToGrid,
   type CellInfo,
   type RowData,
@@ -544,5 +551,92 @@ describe('parseInlineMarkdown', () => {
       { type: 'text', value: ' and ' },
       { type: 'bold', value: 'b' },
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// routeLinkClick
+// ---------------------------------------------------------------------------
+
+// Structural mock — mirrors the pattern used in heading-slugs.test.ts. Only
+// `state` and `dispatch` are exercised by navigateToHeading, so a real
+// EditorView (which needs the DOM) isn't required.
+function makeMockView(doc: string): { view: EditorView; dispatch: ReturnType<typeof vi.fn> } {
+  const dispatch = vi.fn();
+  const state = EditorState.create({
+    doc,
+    extensions: [
+      markdown({
+        base: markdownLanguage,
+        codeLanguages: languages,
+        extensions: [Strikethrough, Table],
+      }),
+      headingSlugsField,
+    ],
+  });
+  const view = { state, dispatch } as unknown as EditorView;
+  return { view, dispatch };
+}
+
+describe('routeLinkClick', () => {
+  it('Anchor_KnownHeading_DispatchesScrollAndSkipsOpenExternal', () => {
+    const { view, dispatch } = makeMockView('# Hello\n\nbody\n');
+    const openExternal = vi.fn();
+
+    routeLinkClick('#hello', view, openExternal);
+
+    // navigateToHeading dispatches a single transaction with scrollIntoView effects.
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('Anchor_UnknownHeading_DispatchesNothingAndSkipsOpenExternal', () => {
+    const { view, dispatch } = makeMockView('# Hello\n');
+    const openExternal = vi.fn();
+
+    routeLinkClick('#nope', view, openExternal);
+
+    // navigateToHeading is a silent no-op for unknown slugs — must not fall
+    // through to the external opener.
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('Anchor_RepeatedClicks_RouteThroughDispatchEveryTime_NeverEscapesToExternal', () => {
+    // Repro for the regression: re-clicking the same in-document anchor used
+    // to escape through the native `<a href="#x">` activation and end up in
+    // the system browser. Routing must stay deterministic across N calls and
+    // openExternal must never be invoked for `#`-prefixed URLs.
+    const { view, dispatch } = makeMockView('# Hello\n\nbody\n');
+    const openExternal = vi.fn();
+
+    routeLinkClick('#hello', view, openExternal);
+    routeLinkClick('#hello', view, openExternal);
+    routeLinkClick('#hello', view, openExternal);
+
+    expect(dispatch).toHaveBeenCalledTimes(3);
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('External_HttpUrl_InvokesOpenExternalAndSkipsDispatch', () => {
+    const { view, dispatch } = makeMockView('# Hello\n');
+    const openExternal = vi.fn();
+
+    routeLinkClick('https://example.com/path', view, openExternal);
+
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://example.com/path');
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('External_DoesNotMistakeMidStringHashForAnchor', () => {
+    // Only a leading `#` marks an in-document anchor — full URLs with fragments
+    // (`https://x.test/page#section`) must still open externally.
+    const { view, dispatch } = makeMockView('# Hello\n');
+    const openExternal = vi.fn();
+
+    routeLinkClick('https://x.test/page#section', view, openExternal);
+
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://x.test/page#section');
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/editor/preview/tables.test.ts
+++ b/src/lib/editor/preview/tables.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   parseCellsWithPositions,
+  parseInlineMarkdown,
   tableToGrid,
   type CellInfo,
   type RowData,
@@ -445,5 +446,103 @@ describe('delimiter detection (position-based)', () => {
     expect(grid).toHaveLength(2);
     // 'Alice' (second row, treated as delimiter) must NOT appear in the grid
     expect(grid.flat()).not.toContain('Alice');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseInlineMarkdown
+// ---------------------------------------------------------------------------
+
+describe('parseInlineMarkdown', () => {
+  it('Empty_Empty_ReturnsEmptyArray', () => {
+    expect(parseInlineMarkdown('')).toEqual([]);
+  });
+
+  it('PlainText_NoMarkdown_ReturnsSingleTextToken', () => {
+    expect(parseInlineMarkdown('hello world')).toEqual([
+      { type: 'text', value: 'hello world' },
+    ]);
+  });
+
+  it('Link_BareLink_ReturnsLinkToken', () => {
+    expect(parseInlineMarkdown('[click](https://example.com)')).toEqual([
+      { type: 'link', text: 'click', url: 'https://example.com' },
+    ]);
+  });
+
+  it('Link_IssueShorthandWithHash_ReturnsLinkToken', () => {
+    // Real-world case from the bug report: `[#12480](https://github.com/.../issues/12480)`
+    expect(
+      parseInlineMarkdown('[#12480](https://github.com/dodobrands/dodo-mobile-ios/issues/12480)')
+    ).toEqual([
+      {
+        type: 'link',
+        text: '#12480',
+        url: 'https://github.com/dodobrands/dodo-mobile-ios/issues/12480',
+      },
+    ]);
+  });
+
+  it('Link_MultipleLinksSeparatedByText_ReturnsInterleavedTokens', () => {
+    expect(
+      parseInlineMarkdown('[#1](https://x.test/1), [#2](https://x.test/2)')
+    ).toEqual([
+      { type: 'link', text: '#1', url: 'https://x.test/1' },
+      { type: 'text', value: ', ' },
+      { type: 'link', text: '#2', url: 'https://x.test/2' },
+    ]);
+  });
+
+  it('Link_TextBeforeAndAfter_ReturnsTextLinkText', () => {
+    expect(parseInlineMarkdown('see [docs](https://example.com) now')).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'link', text: 'docs', url: 'https://example.com' },
+      { type: 'text', value: ' now' },
+    ]);
+  });
+
+  it('Bold_DoubleAsterisk_ReturnsBoldToken', () => {
+    expect(parseInlineMarkdown('**bold**')).toEqual([
+      { type: 'bold', value: 'bold' },
+    ]);
+  });
+
+  it('Italic_SingleAsterisk_ReturnsItalicToken', () => {
+    expect(parseInlineMarkdown('*italic*')).toEqual([
+      { type: 'italic', value: 'italic' },
+    ]);
+  });
+
+  it('BoldItalic_TripleAsterisk_ReturnsBoldItalicToken', () => {
+    expect(parseInlineMarkdown('***both***')).toEqual([
+      { type: 'boldItalic', value: 'both' },
+    ]);
+  });
+
+  it('Strike_DoubleTilde_ReturnsStrikeToken', () => {
+    expect(parseInlineMarkdown('~~gone~~')).toEqual([
+      { type: 'strike', value: 'gone' },
+    ]);
+  });
+
+  it('Code_Backticks_ReturnsCodeToken', () => {
+    expect(parseInlineMarkdown('`code`')).toEqual([
+      { type: 'code', value: 'code' },
+    ]);
+  });
+
+  it('MalformedLink_MissingClosingParen_NotParsedAsLink', () => {
+    // Defensive: opener without closing must remain plain text, not swallow rest of cell.
+    expect(parseInlineMarkdown('[oops](https://x.test')).toEqual([
+      { type: 'text', value: '[oops](https://x.test' },
+    ]);
+  });
+
+  it('LinkWithBoldNeighbours_LinkBeforeBold_BothParsed', () => {
+    expect(parseInlineMarkdown('[a](https://x.test) and **b**')).toEqual([
+      { type: 'link', text: 'a', url: 'https://x.test' },
+      { type: 'text', value: ' and ' },
+      { type: 'bold', value: 'b' },
+    ]);
   });
 });

--- a/src/lib/editor/preview/tables.ts
+++ b/src/lib/editor/preview/tables.ts
@@ -446,63 +446,140 @@ class TableWidget extends WidgetType {
   }
 }
 
-/** Render inline markdown (code, bold, italic, strikethrough) into a cell element. */
-function renderCellContent(cellEl: HTMLElement, text: string): void {
-  if (!text) return;
+export type InlineToken =
+  | { type: 'text'; value: string }
+  | { type: 'code'; value: string }
+  | { type: 'boldItalic'; value: string }
+  | { type: 'bold'; value: string }
+  | { type: 'italic'; value: string }
+  | { type: 'strike'; value: string }
+  | { type: 'link'; text: string; url: string };
 
-  // Regex for inline markdown tokens — order matters (longer patterns first)
-  const inlineRegex = /(`+)(.*?)\1|(\*\*\*|___)(.*?)\3|(\*\*|__)(.*?)\5|(\*|_)(.*?)\7|(~~)(.*?)\9/g;
+/**
+ * Parse a cell's text into inline markdown tokens.
+ *
+ * Supported: code, bold+italic, bold, italic, strikethrough, links `[text](url)`.
+ * Order matters — longer patterns are matched first to avoid emphasis swallowing link
+ * brackets. Unmatched text becomes `text` tokens.
+ */
+export function parseInlineMarkdown(text: string): InlineToken[] {
+  if (!text) return [];
 
+  // Order: code | link | ***bi*** | **b** | *i* | ~~s~~. Link before emphasis so the
+  // square brackets don't get treated as italic-eligible text.
+  const inlineRegex = /(`+)(.*?)\1|\[([^\]\n]+)\]\(([^)\s]+)\)|(\*\*\*|___)(.*?)\5|(\*\*|__)(.*?)\7|(\*|_)(.*?)\9|(~~)(.*?)\11/g;
+
+  const tokens: InlineToken[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
   while ((match = inlineRegex.exec(text)) !== null) {
-    // Append plain text before this match
     if (match.index > lastIndex) {
-      cellEl.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
+      tokens.push({ type: 'text', value: text.slice(lastIndex, match.index) });
     }
 
-    if (match[1]) {
-      // Code: `code` or ``code``
-      const code = document.createElement('code');
-      code.className = 'cm-md-table-inline-code';
-      code.textContent = match[2];
-      cellEl.appendChild(code);
-    } else if (match[3]) {
-      // Bold+italic: ***text*** or ___text___
-      const el = document.createElement('strong');
-      const em = document.createElement('em');
-      em.textContent = match[4];
-      el.appendChild(em);
-      cellEl.appendChild(el);
-    } else if (match[5]) {
-      // Bold: **text** or __text__
-      const el = document.createElement('strong');
-      el.textContent = match[6];
-      cellEl.appendChild(el);
-    } else if (match[7]) {
-      // Italic: *text* or _text_
-      const el = document.createElement('em');
-      el.textContent = match[8];
-      cellEl.appendChild(el);
-    } else if (match[9]) {
-      // Strikethrough: ~~text~~
-      const el = document.createElement('s');
-      el.textContent = match[10];
-      cellEl.appendChild(el);
+    if (match[1] !== undefined) {
+      tokens.push({ type: 'code', value: match[2] });
+    } else if (match[3] !== undefined) {
+      tokens.push({ type: 'link', text: match[3], url: match[4] });
+    } else if (match[5] !== undefined) {
+      tokens.push({ type: 'boldItalic', value: match[6] });
+    } else if (match[7] !== undefined) {
+      tokens.push({ type: 'bold', value: match[8] });
+    } else if (match[9] !== undefined) {
+      tokens.push({ type: 'italic', value: match[10] });
+    } else if (match[11] !== undefined) {
+      tokens.push({ type: 'strike', value: match[12] });
     }
 
     lastIndex = match.index + match[0].length;
   }
 
-  // Append remaining plain text
   if (lastIndex < text.length) {
-    cellEl.appendChild(document.createTextNode(text.slice(lastIndex)));
+    tokens.push({ type: 'text', value: text.slice(lastIndex) });
   }
 
-  // If nothing was parsed (no inline markdown), just set text
-  if (lastIndex === 0) {
+  return tokens;
+}
+
+/** Open a URL via the Tauri shell, falling back to `window.open` in non-Tauri builds. */
+function openUrl(url: string): void {
+  import('@tauri-apps/plugin-shell')
+    .then(({ open }) => open(url))
+    .catch(() => {
+      window.open(url, '_blank');
+    });
+}
+
+/** Render inline markdown (code, bold, italic, strikethrough, links) into a cell element. */
+function renderCellContent(cellEl: HTMLElement, text: string): void {
+  if (!text) return;
+
+  const tokens = parseInlineMarkdown(text);
+
+  if (tokens.length === 0) {
     cellEl.textContent = text;
+    return;
+  }
+
+  for (const token of tokens) {
+    switch (token.type) {
+      case 'text':
+        cellEl.appendChild(document.createTextNode(token.value));
+        break;
+      case 'code': {
+        const code = document.createElement('code');
+        code.className = 'cm-md-table-inline-code';
+        code.textContent = token.value;
+        cellEl.appendChild(code);
+        break;
+      }
+      case 'boldItalic': {
+        const strong = document.createElement('strong');
+        const em = document.createElement('em');
+        em.textContent = token.value;
+        strong.appendChild(em);
+        cellEl.appendChild(strong);
+        break;
+      }
+      case 'bold': {
+        const el = document.createElement('strong');
+        el.textContent = token.value;
+        cellEl.appendChild(el);
+        break;
+      }
+      case 'italic': {
+        const el = document.createElement('em');
+        el.textContent = token.value;
+        cellEl.appendChild(el);
+        break;
+      }
+      case 'strike': {
+        const el = document.createElement('s');
+        el.textContent = token.value;
+        cellEl.appendChild(el);
+        break;
+      }
+      case 'link': {
+        const a = document.createElement('a');
+        a.className = 'cm-md-link';
+        a.href = token.url;
+        a.target = '_blank';
+        a.rel = 'noopener noreferrer';
+        a.textContent = token.text;
+        // Open via Tauri shell. preventDefault so the <a> doesn't navigate the
+        // editor window; stopPropagation so the editor's global Link handler
+        // and the cell's dblclick-to-edit don't also fire.
+        a.addEventListener('mousedown', (e) => {
+          if (e.button !== 0) return;
+          e.preventDefault();
+          e.stopPropagation();
+          openUrl(token.url);
+        });
+        cellEl.appendChild(a);
+        break;
+      }
+    }
   }
 }
 

--- a/src/lib/editor/preview/tables.ts
+++ b/src/lib/editor/preview/tables.ts
@@ -5,6 +5,7 @@ import type { SyntaxNode } from '@lezer/common';
 import { markdownTable } from 'markdown-table';
 import { toggleTableMode, getTableMode } from './table-state';
 import { encodeForCommit, decodeForEdit } from './table-encoding';
+import { navigateToHeading } from '../heading-slugs';
 
 export interface CellInfo {
   text: string;
@@ -512,7 +513,7 @@ function openUrl(url: string): void {
 }
 
 /** Render inline markdown (code, bold, italic, strikethrough, links) into a cell element. */
-function renderCellContent(cellEl: HTMLElement, text: string): void {
+function renderCellContent(cellEl: HTMLElement, text: string, view: EditorView): void {
   if (!text) return;
 
   const tokens = parseInlineMarkdown(text);
@@ -567,14 +568,20 @@ function renderCellContent(cellEl: HTMLElement, text: string): void {
         a.target = '_blank';
         a.rel = 'noopener noreferrer';
         a.textContent = token.text;
-        // Open via Tauri shell. preventDefault so the <a> doesn't navigate the
-        // editor window; stopPropagation so the editor's global Link handler
-        // and the cell's dblclick-to-edit don't also fire.
+        // preventDefault so the <a> doesn't navigate the editor window;
+        // stopPropagation so the editor's global Link handler and the cell's
+        // dblclick-to-edit don't also fire. Anchor links (`#heading`) jump
+        // within the document via the same path as top-level links in setup.ts;
+        // everything else goes through the Tauri shell.
         a.addEventListener('mousedown', (e) => {
           if (e.button !== 0) return;
           e.preventDefault();
           e.stopPropagation();
-          openUrl(token.url);
+          if (token.url.startsWith('#')) {
+            navigateToHeading(view, token.url.slice(1));
+          } else {
+            openUrl(token.url);
+          }
         });
         cellEl.appendChild(a);
         break;
@@ -672,7 +679,7 @@ function buildCell(
   const cellEl = document.createElement('span');
   cellEl.className = 'cm-md-table-cell';
   if (isHeader) cellEl.classList.add('cm-md-table-cell-header');
-  renderCellContent(cellEl, cell.text);
+  renderCellContent(cellEl, cell.text, view);
 
   cellEl.addEventListener('dblclick', (e) => {
     e.preventDefault();

--- a/src/lib/editor/preview/tables.ts
+++ b/src/lib/editor/preview/tables.ts
@@ -512,6 +512,31 @@ function openUrl(url: string): void {
     });
 }
 
+/**
+ * Route a link click from inside a table cell.
+ *
+ * Anchor URLs (`#heading-slug`) jump within the document via `navigateToHeading`;
+ * everything else is opened externally through the supplied `openExternal` callback
+ * (Tauri shell in the live editor, injectable in tests).
+ *
+ * Pure — does not touch the click event itself. The DOM wiring layer is responsible
+ * for `preventDefault` / `stopPropagation` so the native `<a>` activation doesn't
+ * also fire. Without that, a re-click of the same anchor lets the browser's hash
+ * navigation kick in, which Tauri can then open in the system browser instead of
+ * scrolling the editor.
+ */
+export function routeLinkClick(
+  url: string,
+  view: EditorView,
+  openExternal: (url: string) => void
+): void {
+  if (url.startsWith('#')) {
+    navigateToHeading(view, url.slice(1));
+  } else {
+    openExternal(url);
+  }
+}
+
 /** Render inline markdown (code, bold, italic, strikethrough, links) into a cell element. */
 function renderCellContent(cellEl: HTMLElement, text: string, view: EditorView): void {
   if (!text) return;
@@ -565,24 +590,27 @@ function renderCellContent(cellEl: HTMLElement, text: string, view: EditorView):
         const a = document.createElement('a');
         a.className = 'cm-md-link';
         a.href = token.url;
-        a.target = '_blank';
         a.rel = 'noopener noreferrer';
         a.textContent = token.text;
-        // preventDefault so the <a> doesn't navigate the editor window;
-        // stopPropagation so the editor's global Link handler and the cell's
-        // dblclick-to-edit don't also fire. Anchor links (`#heading`) jump
-        // within the document via the same path as top-level links in setup.ts;
-        // everything else goes through the Tauri shell.
-        a.addEventListener('mousedown', (e) => {
+        // mousedown drives the actual routing — same trigger setup.ts uses for
+        // top-level Link nodes. The click handler is a backstop that kills the
+        // native `<a>` activation on every code path (keyboard activation,
+        // re-clicks after the widget has been re-rendered): without it, the
+        // webview honours the `href` and re-opens `#anchor` URLs in the system
+        // browser on the second click. No `target="_blank"` — it would route
+        // every click through the OS handler too.
+        const onMouseDown = (e: MouseEvent): void => {
           if (e.button !== 0) return;
           e.preventDefault();
           e.stopPropagation();
-          if (token.url.startsWith('#')) {
-            navigateToHeading(view, token.url.slice(1));
-          } else {
-            openUrl(token.url);
-          }
-        });
+          routeLinkClick(token.url, view, openUrl);
+        };
+        const onClick = (e: MouseEvent): void => {
+          e.preventDefault();
+          e.stopPropagation();
+        };
+        a.addEventListener('mousedown', onMouseDown);
+        a.addEventListener('click', onClick);
         cellEl.appendChild(a);
         break;
       }


### PR DESCRIPTION
## Symptom

Inside table cells, Markdown links rendered as literal source instead of clickable links:

```
| PR'ы | [#12480](https://github.com/.../issues/12480), [#12493](https://github.com/.../issues/12493) |
```

displayed the raw brackets, parens, and URL text.

Then once the rendering was in place, two follow-up regressions surfaced:

1. **Anchor links** (`[Back to top](#some-heading)`) didn't scroll the editor — they were treated as external URLs and silently no-op'd through the Tauri shell.
2. **Re-clicking** the same in-document anchor opened it in the **system browser**. First click worked, every click after that escaped.

## Root cause

The cell inline scanner only matched code / bold / italic / strikethrough. `[text](url)` had no alternation, so the regex fell through and the raw substring was appended as plain text.

For the anchor regression — the rendered `<a>` was decorated with `target="_blank"` and a real `href`, so the native activation kept firing on every click. The first click happened to win the race: `navigateToHeading` ran, the editor scrolled, and the widget's `<a>` was often detached before the trailing `click` event landed, swallowing the native default. On the second click the cursor was already at the heading, the widget stayed put, and the not-suppressed-by-luck default click finally went through — the webview followed the `target="_blank"` hint and Tauri opened `#anchor` in the OS browser.

## Behaviour after the fix

| Click target | What happens now |
|---|---|
| `[text](https://example.com)` in a cell | mousedown → `routeLinkClick` → `openUrl` → `@tauri-apps/plugin-shell.open()` (falls back to `window.open` in `npm run dev`). Native `<a>` activation suppressed on both `mousedown` and `click`. |
| `[Back to top](#table-cell-links-demo)` in a cell | mousedown → `routeLinkClick` → `navigateToHeading(view, 'table-cell-links-demo')` (same slugify + scroll-into-view path setup.ts uses for top-level Link nodes, including unfold-if-collapsed). |
| Same anchor clicked again | Identical behaviour — `routeLinkClick` is pure and runs on every click. No reliance on the widget being detached mid-event to suppress the default. |
| Unknown anchor (`#nope`) | Silent no-op (consistent with the top-level handler — `navigateToHeading` short-circuits when the slug isn't in `headingSlugsField`). |
| External URL with a `#fragment` (`https://x.test/page#section`) | Goes to `openExternal`, **not** treated as an in-document anchor. Only a leading `#` triggers the anchor branch. |
| Double-click on a link | The cell's dblclick-to-edit doesn't fire — both link listeners call `stopPropagation`, so the dblclick event composition never reaches the cell. |
| Keyboard activation of a focused link (Enter / Space) | Synthesized `click` event hits the backstop handler → `preventDefault` → native `<a>` activation suppressed. (Routing in this path still goes through `mousedown`-equivalent only on real mouse interaction; keyboard activation is currently swallowed rather than routed. Worth a follow-up — out of scope for the bug at hand.) |

## What changed

- **Inline parser.** Extracted the cell scanner into a pure `parseInlineMarkdown(text)` returning typed tokens (`text` / `code` / `bold` / `italic` / `boldItalic` / `strike` / `link`). Added a link alternation, placed **before** the emphasis alternations so the `[…]` brackets aren't consumed by `*` / `_` runs that surround the link.
- **Click routing.** Added a pure `routeLinkClick(url, view, openExternal)` that branches on a leading `#`: anchor → `navigateToHeading`, anything else → `openExternal`. Injectable third argument keeps it node-testable without touching the Tauri shell.
- **DOM wiring.** Rendered link tokens as `<a class="cm-md-link" rel="noopener noreferrer">` with no `target="_blank"`. Bound **two** listeners — `mousedown` does the actual routing (matches the trigger setup.ts uses for top-level Link nodes), `click` is a backstop that calls `preventDefault` + `stopPropagation` on every code path. Both stop propagation so the editor's global Link handler and the cell's dblclick-to-edit don't piggyback on the same event.

## Tests

`src/lib/editor/preview/tables.test.ts` gains two new suites, **17 new test cases** total:

`parseInlineMarkdown` (12 cases):
- Empty input, plain text passthrough.
- Bare link, issue-shorthand `[#12480](...)` (the real-world case from #3), multiple links separated by text, links surrounded by plain text, link with bold neighbour.
- All four emphasis tokens (`**bold**`, `*italic*`, `***boldItalic***`, `~~strike~~`).
- Code spans.
- Malformed link (missing closing paren) stays as plain text and doesn't swallow the rest of the cell.

`routeLinkClick` (5 cases):
- Anchor to a known heading → exactly one `view.dispatch`, `openExternal` not invoked.
- Anchor to an unknown heading → no dispatch, no external open (defensive — anchors must not "fall through" to the external opener).
- Same anchor clicked 3× → 3 dispatches, 0 external opens (regression guard for the browser-escape bug).
- Plain external URL → exactly one `openExternal(url)`, no dispatch.
- External URL with a mid-string `#` (`https://x.test/page#section`) → still goes to `openExternal`, doesn't get mistaken for an in-document anchor.

## Test plan

- [x] `npm run test` — 8 files / 170 tests passed (46 in `tables.test.ts`, including the new `parseInlineMarkdown` and `routeLinkClick` suites).
- [x] `svelte-check` — touched files clean; two pre-existing errors in `App.svelte` (`select_all`, `toggle_line_glow` MenuAction) are unrelated.
- [x] Manual via `npm run dev:app`: opened `/tmp/table-links-demo.md` with both external and anchor links in cells. External opens in browser via Tauri shell, anchor scrolls within the document. Re-clicking the same anchor scrolls again, never escapes to the browser.

Closes #3