### PR TITLE
fix(editor): preserve scroll and caret on external file reload

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -199,7 +199,7 @@
       // Silently reload
       try {
         const content = await readFile(path);
-        editorHandle?.replaceContent(content);
+        editorHandle?.updateContent(content);
         fileState.isDirty = false;
       } catch (err) {
         console.error('Failed to reload externally changed file:', err);
@@ -213,7 +213,7 @@
       if (reload) {
         try {
           const content = await readFile(path);
-          editorHandle?.replaceContent(content);
+          editorHandle?.updateContent(content);
           fileState.isDirty = false;
         } catch (err) {
           console.error('Failed to reload externally changed file:', err);

--- a/src/lib/editor/Editor.svelte
+++ b/src/lib/editor/Editor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { EditorView } from '@codemirror/view';
-  import { EditorState, Transaction } from '@codemirror/state';
+  import { ChangeSet, EditorState, Transaction } from '@codemirror/state';
   import { createExtensions, languageCompartment, previewCompartment } from './setup';
   import { languages } from '@codemirror/language-data';
   import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
@@ -10,10 +10,12 @@
   import { Strikethrough, Table } from '@lezer/markdown';
   import { livePreviewPlugin } from './preview/plugin';
   import { envPreviewPlugin } from './preview/env';
+  import { computeReplacement } from './content-diff';
 
   export interface EditorHandle {
     view: EditorView | undefined;
     replaceContent: (newContent: string) => void;
+    updateContent: (newContent: string) => void;
     setCodeMode: (ext: string | null, basename?: string) => void;
     setEnvMode: (enabled: boolean) => void;
   }
@@ -42,6 +44,22 @@
         if (newContent.length > 0) {
           view.contentDOM.blur();
         }
+      },
+      updateContent(newContent: string) {
+        if (!view) return;
+        const repl = computeReplacement(view.state.doc.toString(), newContent);
+        if (!repl) return;
+        // Single-span diff keeps CM6's automatic selection mapping intact and
+        // preserves scroll position — unlike replaceContent's full-doc swap.
+        // scrollSnapshot() captures the anchor at pre-change offsets; it must be
+        // mapped through the same ChangeSet passed to dispatch, or a length-changing
+        // edit above the viewport leaves the anchor pointing at the wrong position.
+        const changes = ChangeSet.of(repl, view.state.doc.length);
+        view.dispatch({
+          changes,
+          effects: view.scrollSnapshot().map(changes) ?? [],
+          annotations: Transaction.addToHistory.of(false),
+        });
       },
       setCodeMode(ext: string | null, basename?: string) {
         if (!view) return;

--- a/src/lib/editor/content-diff.test.ts
+++ b/src/lib/editor/content-diff.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { computeReplacement } from './content-diff';
+
+/** Applies a Replacement through an actual CM6 transaction, so an invalid span throws like production. */
+function applyViaCM6(oldText: string, repl: ReturnType<typeof computeReplacement>): string {
+  if (!repl) return oldText;
+  const state = EditorState.create({ doc: oldText });
+  return state.update({ changes: repl }).state.doc.toString();
+}
+
+describe('computeReplacement', () => {
+  it('IdenticalStrings_ReturnsNull', () => {
+    expect(computeReplacement('hello world', 'hello world')).toBeNull();
+  });
+
+  it('AppendAtEnd_ReplacesOnlyTail', () => {
+    const repl = computeReplacement('hello', 'hello world');
+    expect(repl).toEqual({ from: 5, to: 5, insert: ' world' });
+  });
+
+  it('PrependAtStart_ReplacesOnlyHead', () => {
+    const repl = computeReplacement('world', 'hello world');
+    expect(repl).toEqual({ from: 0, to: 0, insert: 'hello ' });
+  });
+
+  it('InsertionInMiddle_ReplacesOnlyGap', () => {
+    const repl = computeReplacement('ac', 'abc');
+    expect(repl).toEqual({ from: 1, to: 1, insert: 'b' });
+  });
+
+  it('DeletionInMiddle_ReplacesOnlyGap', () => {
+    const repl = computeReplacement('abc', 'ac');
+    expect(repl).toEqual({ from: 1, to: 2, insert: '' });
+  });
+
+  it('FullyDissimilarStrings_ReplacesWholeDoc', () => {
+    const repl = computeReplacement('foo', 'bar');
+    expect(repl).toEqual({ from: 0, to: 3, insert: 'bar' });
+  });
+
+  it('EmptyToText_InsertsAtStart', () => {
+    const repl = computeReplacement('', 'new content');
+    expect(repl).toEqual({ from: 0, to: 0, insert: 'new content' });
+  });
+
+  it('TextToEmpty_DeletesWholeDoc', () => {
+    const repl = computeReplacement('old content', '');
+    expect(repl).toEqual({ from: 0, to: 11, insert: '' });
+  });
+
+  it('TrailingNewlineRemoved_ReplacesOnlyNewline', () => {
+    const repl = computeReplacement('abc\n', 'abc');
+    expect(repl).toEqual({ from: 3, to: 4, insert: '' });
+  });
+
+  it('OverlappingPrefixSuffix_ClampsToValidSpan', () => {
+    // Naive prefix/suffix scans would count the shared 'a' twice (prefix=2, suffix=2
+    // on length-2/3 strings) and produce an out-of-range span. Must clamp.
+    const repl = computeReplacement('aa', 'aaa');
+    expect(repl).not.toBeNull();
+    expect(repl!.from).toBeLessThanOrEqual(repl!.to);
+    expect(applyViaCM6('aa', repl)).toBe('aaa');
+  });
+
+  it('SurrogatePairEdit_RoundTripsExactly', () => {
+    // 😀 (U+1F600) and 😃 (U+1F603) share the same high surrogate, so the
+    // char-code prefix/suffix scan lands its boundary between the high and
+    // low surrogate halves. The resulting span must still recombine correctly
+    // when applied — anything else corrupts the character.
+    const oldText = 'a😀b';
+    const newText = 'a😃b';
+    const repl = computeReplacement(oldText, newText);
+    expect(applyViaCM6(oldText, repl)).toBe(newText);
+  });
+
+  it.each<[string, string, string]>([
+    ['both empty', '', ''],
+    ['single char unchanged', 'a', 'a'],
+    ['single char append', 'a', 'aa'],
+    ['single char delete', 'aa', 'a'],
+    ['identical multi-char', 'aaa', 'aaa'],
+    ['shrink repeated char', 'aaaa', 'aa'],
+    ['middle substitution', 'abcdef', 'abXYdef'],
+    ['markdown body edit', '# Title\n\nBody text.\n', '# Title\n\nBody text, edited.\n'],
+    ['single word changed mid-document', 'line1\nline2\nline3', 'line1\nlineTWO\nline3'],
+    ['delete everything', 'xyz', ''],
+    ['insert into empty doc', '', 'xyz'],
+  ])('RoundTrip_%s', (_label, oldText, newText) => {
+    const repl = computeReplacement(oldText, newText);
+    expect(applyViaCM6(oldText, repl)).toBe(newText);
+  });
+});
+
+describe('computeReplacement + CM6 transaction', () => {
+  it('AppendedText_SelectionHeadUnchanged', () => {
+    const oldText = 'line1\nline2\nline3';
+    const state = EditorState.create({
+      doc: oldText,
+      selection: { anchor: 8 }, // inside "line2"
+    });
+
+    const newText = oldText + '\nline4';
+    const repl = computeReplacement(oldText, newText);
+    expect(repl).not.toBeNull();
+
+    const tr = state.update({ changes: repl! });
+    expect(tr.state.doc.toString()).toBe(newText);
+    // The edit is entirely after the selection, so CM6's automatic mapping
+    // must leave the head exactly where it was.
+    expect(tr.state.selection.main.head).toBe(8);
+  });
+
+  it('PrependedText_SelectionHeadShiftsByInsertionLength', () => {
+    const oldText = 'line1\nline2\nline3';
+    const state = EditorState.create({
+      doc: oldText,
+      selection: { anchor: 8 }, // inside "line2"
+    });
+
+    const newText = 'HEADER\n' + oldText;
+    const repl = computeReplacement(oldText, newText);
+    expect(repl).toEqual({ from: 0, to: 0, insert: 'HEADER\n' });
+
+    const tr = state.update({ changes: repl! });
+    expect(tr.state.doc.toString()).toBe(newText);
+    // The insertion is entirely before the selection, so the head must shift
+    // by exactly the inserted length (7 chars: "HEADER\n").
+    expect(tr.state.selection.main.head).toBe(15);
+  });
+
+  it('CaretInsideReplacedSpan_CollapsesToChangeStart', () => {
+    const oldText = 'aaa BBBB ccc';
+    const state = EditorState.create({
+      doc: oldText,
+      selection: { anchor: 6 }, // inside the "BBBB" span that gets replaced
+    });
+
+    const newText = 'aaa XYZ ccc';
+    const repl = computeReplacement(oldText, newText);
+    expect(repl).toEqual({ from: 4, to: 8, insert: 'XYZ' });
+
+    const tr = state.update({ changes: repl! });
+    expect(tr.state.doc.toString()).toBe(newText);
+    // A caret that lands inside a replaced span has no stable position to map
+    // to — CM6's default mapping collapses it to the start of the change.
+    expect(tr.state.selection.main.head).toBe(4);
+  });
+});

--- a/src/lib/editor/content-diff.ts
+++ b/src/lib/editor/content-diff.ts
@@ -1,0 +1,32 @@
+export interface Replacement {
+  from: number;
+  to: number;
+  insert: string;
+}
+
+/** Minimal single-span replacement turning oldText into newText, or null if identical. */
+export function computeReplacement(oldText: string, newText: string): Replacement | null {
+  if (oldText === newText) return null;
+
+  const maxCommon = Math.min(oldText.length, newText.length);
+
+  let prefix = 0;
+  while (prefix < maxCommon && oldText.charCodeAt(prefix) === newText.charCodeAt(prefix)) {
+    prefix++;
+  }
+
+  let suffix = 0;
+  const maxSuffix = maxCommon - prefix;
+  while (
+    suffix < maxSuffix &&
+    oldText.charCodeAt(oldText.length - 1 - suffix) === newText.charCodeAt(newText.length - 1 - suffix)
+  ) {
+    suffix++;
+  }
+
+  return {
+    from: prefix,
+    to: oldText.length - suffix,
+    insert: newText.slice(prefix, newText.length - suffix),
+  };
+}


### PR DESCRIPTION
## Problem

When an external process (e.g. an AI agent) rewrites the file open in md-mini, the watcher-driven reload replaced the whole document, moved the caret to the end of the file, blurred the editor, and made the view jump — usually to the top.

## Fix

- New pure utility `src/lib/editor/content-diff.ts`: `computeReplacement()` — minimal single-span diff (common prefix/suffix, overlap-clamped).
- New `EditorHandle.updateContent()`: dispatches only the changed span, with the scroll snapshot **explicitly mapped through the ChangeSet** — CM6 does not map effects through changes of the same transaction, so an unmapped snapshot drifts on length-changing edits above the viewport (caught in review).
- `handleExternalChange` (both branches) now uses `updateContent`; `replaceContent` stays for open-file / session-restore / drag-drop, where the caret reset is intentional.

Side benefit: selection, mermaid zoom/pan, and table view modes are mapped through the reload instead of being wiped.

## Testing

- `npx vitest run --dir src`: 287 passed (was 252) — diff round-trips through real CM6 transactions, selection mapping (prepend above caret, caret inside replaced span), surrogate pairs, trailing-newline edge.
- `npm run check`: 0 errors, 0 warnings.
- Passed code review; the HIGH finding (unmapped scrollSnapshot) is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)