### PR TITLE
feat(ai): make the AI interface discoverable

### DIFF
--- a/docs/ai-interface.md
+++ b/docs/ai-interface.md
@@ -223,6 +223,26 @@ All three verbs print one line of JSON to stdout: `{"ok":true}` (plus `"changed_
 
 Prefer MCP? `claude mcp add --scope user mdmini -- mdmini mcp` registers md-mini's show/edit/ask tools directly — then no instruction-file snippet is needed; run `mdmini agent --mcp` for a short usage-culture snippet worth pasting alongside it.
 
+## Discoverability
+
+None of the above helps a user who doesn't know the interface exists — the reported failure
+mode after 1.0. Three surfaces address it, and all three name the same place, the **AI** menu's
+**Getting Started**, so someone who sets this up once and forgets has a way back. Design:
+`docs/superpowers/specs/2026-08-23-ai-discoverability-design.md`.
+
+| Surface | Raised when |
+|---------|-------------|
+| Startup toast (`ai-nudge`) | `main` window, at launch, while `ai-connected` is absent: at most 3 times, at most once a day, never on a launch that also opened the welcome window. Following or closing it retires it permanently (`ai-nudge.json` → `dismissed`). |
+| `Getting Started` doc | The toast's CTA and the first item of the AI menu — the same document either way (`getting-started-ai.md`, bundled). Its lead block is a map of the AI menu, not setup instructions. |
+| First-use toast (`ai-first-use`) | The first AI command this install ever handles. |
+
+Both the marker and the toast come out of one check-and-set: `dispatch` calls
+`onboarding::mark_connected` after validation but before routing, and the single call that
+observes the transition sets `first_use: true` on that command's `AiCommandPayload`. Riding the
+payload rather than a separate event means a command drained from `AiQueue` by a window that
+didn't exist yet carries it too. Exactly one command per install can ever carry the flag; a
+rejected request never burns it.
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |

--- a/docs/superpowers/specs/2026-08-23-ai-discoverability-design.md
+++ b/docs/superpowers/specs/2026-08-23-ai-discoverability-design.md
@@ -1,0 +1,160 @@
+# AI Interface Discoverability — Design
+
+**Date:** 2026-08-23
+**Status:** Approved, ready for implementation
+
+## Problem
+
+md-mini 1.0 shipped the AI interface (`show` / `edit` / `ask`, CLI + MCP). Users report they
+don't know the feature exists. The existing surfaces are both passive and one-shot:
+
+- `welcome.md` opens once per version (`onboarding.rs`, marker `onboarding-version`) and is
+  then gone — closed, forgotten, unrecoverable except by deleting the marker.
+- The **AI** menu holds all four docs, but you have to already suspect it's there to look.
+
+The confirmed failure mode is pure visibility: people don't know the feature exists at all.
+A secondary failure follows from it and matters more in the long run — someone who *does*
+set it up once, forgets, and needs it again a month later has no path back, because every
+surface we have is one-shot.
+
+## Design principle
+
+Every surface must **name the place the feature permanently lives** — "the **AI** menu →
+**Getting Started**" — even when the user never clicks. Retention comes from repeating one
+name in three places, not from the length of any single document.
+
+## Surfaces
+
+### 1. Startup toast (`kind: 'ai-nudge'`)
+
+Rendered by the existing `ToastStack`, only in the `main` window at launch — same rule the
+session toast already follows, because showing it in every window is noise.
+
+```
+╭──────────────────────────────────────────────╮
+│ Your AI can drive md-mini  ·  see the AI menu│
+│ [ Getting Started ]                        ✕ │
+╰──────────────────────────────────────────────╯
+```
+
+The menu name is in the body text, not only on the button, so a dismissed toast still
+delivers the one fact that matters. Does not auto-dismiss — consistent with every other
+toast in the app.
+
+### 2. "Getting Started" document + menu anchor
+
+A new bundled doc, opened by the toast's CTA **and** installed as the first item of the
+**AI** menu. The same name appears in the toast, the document's `<h1>`, and the menu item;
+that repetition is the retention mechanism.
+
+Its lead block is a map of the menu, not a setup instruction:
+
+```
+AI
+├── Getting Started        ← this document
+├── Connect AI via CLI     ← snippet to paste into CLAUDE.md / AGENTS.md
+├── Connect AI via MCP     ← one command for Claude Code
+├── Teach your AI md-mini  ← how your agent should use it well
+└── AI Playbook            ← what to actually do with it
+```
+
+The AI menu becomes:
+
+| Item | Note |
+|------|------|
+| Getting Started | **new**, first |
+| *(separator)* | **new** |
+| Connect AI via CLI | unchanged |
+| Connect AI via MCP | unchanged |
+| Teach your AI md-mini | unchanged |
+| *(separator)* | unchanged |
+| AI Playbook | unchanged |
+
+The rest of the document: connect in a minute (MCP one-liner / `mdmini agent`), a one-sentence
+way to verify it works, the show/edit/ask table, and the Esc / Cmd+Z notes.
+
+The same menu-map block is added to `welcome.md`. First-run users see the welcome window, and
+they are exactly the population that later forgets where this lives.
+
+### 3. First-AI-action toast (`kind: 'ai-first-use'`)
+
+Shown in the window that receives the very first AI command this install ever handles — the
+moment of peak attention, and the only surface that reaches users whose agent config arrived
+pre-made from a colleague.
+
+```
+╭──────────────────────────────────────────────╮
+│ That was your AI · md-mini is connected      │
+│ More in the AI menu → Getting Started      ✕ │
+╰──────────────────────────────────────────────╯
+```
+
+## State
+
+Two files in `paths::app_data_dir()`, alongside `onboarding-version` (so a dev build is
+naturally isolated from a release install — see `paths.rs`):
+
+| File | Contents |
+|------|----------|
+| `ai-connected` | App version at the moment of the first successful command-socket request. Written exactly once. |
+| `ai-nudge.json` | `{"shown": N, "last_shown": <epoch secs>, "dismissed": bool}` |
+
+### Startup toast rules
+
+Show when **all** hold:
+
+- `ai-connected` does not exist (never connected)
+- `dismissed` is false
+- `shown < 3`
+- `now - last_shown >= 24h`
+- the welcome window was **not** opened on this launch (otherwise we duplicate ourselves)
+
+Returning true increments `shown` and stamps `last_shown`. Clicking the CTA or the ✕ sets
+`dismissed: true` — permanent. Nothing revives it.
+
+### First-use detection
+
+Writing `ai-connected` and raising the first-use toast are **one event**. The command-socket
+dispatcher does a check-and-set on the marker; when the transition actually happens, it sets
+`first_use: true` on the emitted `ai-command` payload. The frontend raises the toast on seeing
+the flag. Because the flag rides the payload, it works identically for a command emitted to a
+live window and for one drained from the queue by a freshly opened window via `ai_pull_pending`.
+
+Check-and-set must be idempotent: exactly one command in the lifetime of an install may carry
+`first_use: true`.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `src-tauri/getting-started-ai.md` | new bundled doc |
+| `src-tauri/welcome.md` | add the menu-map block |
+| `src-tauri/src/onboarding.rs` | `getting_started_doc()`; `NudgeState`; pure `should_nudge(...)`; read/write both markers |
+| `src-tauri/src/menu.rs` | `ai_getting_started` item + separator, first in the AI submenu |
+| `src-tauri/src/lib.rs` | menu handler; register `ai_nudge_pending` / `ai_nudge_dismiss` commands |
+| `src-tauri/src/ai_socket.rs` | check-and-set `ai-connected`, `first_use` flag on the payload |
+| `src/lib/toasts.svelte.ts` | kinds `ai-nudge` / `ai-first-use`; `ORDER`: update 0, session 1, ai 2 |
+| `src/lib/ToastStack.svelte` | render both new toasts |
+| `src/App.svelte` | wire startup nudge (main window only) and first-use flag |
+
+## Testing
+
+Rust:
+
+- `should_nudge` across every branch: already connected, `dismissed`, `shown >= 3`,
+  inside the 24h window, welcome shown this launch, and the happy path
+- `ai-nudge.json` round-trip, including a missing/corrupt file reading as defaults
+- check-and-set idempotence: `first_use` true exactly once, false on every later call
+
+Frontend:
+
+- toast-store ordering with the new kinds
+- `ToastStack` renders each new toast's text and CTA
+
+## Non-goals
+
+- No persistent corner badge, no empty-state block — the app is minimalist and the chosen
+  volume is "a toast at startup".
+- No running `claude mcp add` on the user's behalf.
+- No telemetry.
+- No revival of a dismissed nudge on version bump. Possible later; deliberately out of scope.

--- a/src-tauri/getting-started-ai.md
+++ b/src-tauri/getting-started-ai.md
@@ -1,0 +1,63 @@
+# Getting Started with AI in md-mini
+
+md-mini can be driven by an AI agent. Instead of writing a file to disk and hoping you notice, your agent points at a spot in the document you already have open, pushes an edit into the live buffer with the change highlighted, and asks you questions with real buttons right there in the text.
+
+## Where this lives
+
+Everything about this is in the **AI** menu, in the menu bar. Nothing here is one-time — come back to it whenever you need it:
+
+```
+AI
+├── Getting Started        ← this document
+├── Connect AI via CLI     ← snippet to paste into CLAUDE.md / AGENTS.md
+├── Connect AI via MCP     ← one command for Claude Code
+├── Teach your AI md-mini  ← how your agent should use it well
+└── AI Playbook            ← what to actually do with it
+```
+
+You never have to remember a command. You only have to remember the menu.
+
+## Connect in a minute
+
+Pick whichever matches your agent. Both end up at the same place.
+
+### Claude Code — one command
+
+```bash
+claude mcp add --scope user mdmini -- mdmini mcp
+```
+
+That's the whole setup. The tools describe themselves, so no instruction-file snippet is required.
+
+### Any agent with a shell
+
+```bash
+mdmini agent
+```
+
+Paste what it prints into your agent's instruction file — `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursor/rules`, `.github/copilot-instructions.md`.
+
+## Check that it worked
+
+Ask your agent, in its own chat:
+
+> Open this file in mdmini and highlight the first heading.
+
+A window should come to the front with the heading pulsing. If nothing happens, **Connect AI via CLI** and **Connect AI via MCP** in the AI menu have the exact snippets again.
+
+## What your agent can do
+
+| | |
+|---|---|
+| **show** | Jumps you to a line or a piece of text, with a brief pulse highlight. |
+| **edit** | Rewrites the live buffer — the changed span stays highlighted until you dismiss it. |
+| **ask** | Puts buttons in the document: single choice, checkboxes, or a free-text field. Blocks until you answer. |
+
+## Good to know
+
+- **Esc** hides an AI-edit highlight.
+- **Cmd+Z** undoes an AI edit exactly like any change of your own — nothing is final until you move on.
+- Questions time out after five minutes by default, and you can dismiss one early with ✕.
+- Everything is per-window, so several documents can each have their own question waiting.
+
+Once it's connected, **AI Playbook** in the AI menu is the interesting part — it's about what to do with this, not how to switch it on.

--- a/src-tauri/src/ai_socket.rs
+++ b/src-tauri/src/ai_socket.rs
@@ -441,6 +441,12 @@ pub struct AiCommandPayload {
     /// `ask` only — offers a free-text field alongside the options. `false`
     /// for `show`/`edit`. Wire name `freeText` via the struct's camelCase rename.
     pub free_text: bool,
+    /// True on exactly one command over the lifetime of an install: the first
+    /// one an agent ever delivers. The frontend uses it to say, at the one
+    /// moment the user is definitely paying attention, where this feature
+    /// lives. Rides the payload rather than being a separate event so a command
+    /// pulled from `AiQueue` by a window that did not exist yet carries it too.
+    pub first_use: bool,
 }
 
 /// How long to wait for `open_file_window` (run on the main thread) to register
@@ -498,8 +504,15 @@ fn dispatch(app: &AppHandle, req: AiRequest, tx: mpsc::Sender<AiResponse>) -> u6
     // window's label) happens later, at each point below where the label
     // becomes known.
     let id = app.state::<AiPending>().alloc_id();
+    // Check-and-set, here rather than earlier: the request has passed validation
+    // and is about to be dispatched, so "an agent successfully reached us" is
+    // true. A rejected request must not burn the one first-use notification.
+    let first_use = crate::onboarding::mark_connected(
+        app.config().version.as_deref().unwrap_or("0.0.0"),
+    );
     let payload = AiCommandPayload {
         id,
+        first_use,
         cmd: match &req {
             AiRequest::Show { .. } => "show".to_string(),
             AiRequest::Edit { .. } => "edit".to_string(),
@@ -1463,6 +1476,7 @@ mod tests {
             timeout_secs: 0,
             multi: false,
             free_text: false,
+            first_use: false,
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -73,6 +73,9 @@ pub fn run() {
             watcher::start_watching,
             ai_socket::ai_respond,
             ai_socket::ai_pull_pending,
+            onboarding::ai_nudge_pending,
+            onboarding::ai_nudge_dismiss,
+            onboarding::ai_open_getting_started,
             commands::sync_theme_menu,
             commands::sync_engine_menu,
             commands::sync_beta_in_cycle_menu,
@@ -121,6 +124,16 @@ pub fn run() {
                 // AI menu — each item (re)writes its doc into app_data_dir() with
                 // fresh content and opens it in a new window, so it always reflects
                 // the current snippets rather than a stale cached copy.
+                if id == "ai_getting_started" {
+                    if let Err(e) = onboarding::open_bundled_doc(
+                        &app_handle,
+                        "ai-getting-started.md",
+                        onboarding::getting_started_doc(),
+                    ) {
+                        eprintln!("AI menu: {}", e);
+                    }
+                    return;
+                }
                 if id == "ai_connect_cli" {
                     let content = onboarding::connect_cli_doc();
                     if let Err(e) = onboarding::open_bundled_doc(&app_handle, "ai-connect-cli.md", &content) {

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -198,7 +198,14 @@ pub fn build_menu(
         .quit()
         .build()?;
 
+    // "Getting Started" is deliberately first and deliberately named the same
+    // thing the startup nudge says out loud — a user who half-remembers the
+    // toast a month later scans this menu for that exact phrase.
     let ai_menu = SubmenuBuilder::new(app, "AI")
+        .item(
+            &MenuItemBuilder::with_id("ai_getting_started", "Getting Started").build(app)?,
+        )
+        .separator()
         .item(
             &MenuItemBuilder::with_id("ai_connect_cli", "Connect AI via CLI").build(app)?,
         )

--- a/src-tauri/src/onboarding.rs
+++ b/src-tauri/src/onboarding.rs
@@ -7,6 +7,7 @@
 
 use std::fs;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tauri::AppHandle;
 
@@ -16,6 +17,25 @@ use crate::window;
 const MARKER_FILE: &str = "onboarding-version";
 const WELCOME_MD: &str = include_str!("../welcome.md");
 const PLAYBOOK_MD: &str = include_str!("../playbook.md");
+const GETTING_STARTED_MD: &str = include_str!("../getting-started-ai.md");
+
+/// Written once, the first time an AI command reaches this install over the
+/// command socket. Its presence is what silences the startup nudge forever.
+const CONNECTED_FILE: &str = "ai-connected";
+
+/// Persisted counters for the startup nudge.
+const NUDGE_FILE: &str = "ai-nudge.json";
+
+/// How many times the startup nudge may appear before it gives up on its own.
+const MAX_NUDGE_SHOWS: u32 = 3;
+
+/// Minimum gap between two nudges, so a user who restarts the app five times in
+/// an afternoon sees it once.
+const NUDGE_INTERVAL_SECS: u64 = 24 * 60 * 60;
+
+/// Whether the welcome window opened during *this* launch. The nudge stands down
+/// when it did — the welcome window already says everything the nudge would.
+static WELCOME_SHOWN_THIS_LAUNCH: AtomicBool = AtomicBool::new(false);
 
 /// True when the welcome window should be shown for `current` — the marker is
 /// absent (fresh install / fresh data dir) or names a different version.
@@ -78,10 +98,143 @@ pub fn maybe_show(app: &AppHandle) {
         eprintln!("onboarding: {}", e);
         return;
     }
+    WELCOME_SHOWN_THIS_LAUNCH.store(true, Ordering::SeqCst);
 
     if let Err(e) = write_marker(&base_dir, &version) {
         eprintln!("onboarding: failed to write marker: {}", e);
     }
+}
+
+// ---------------------------------------------------------------------------
+// AI discoverability: the startup nudge and the "first AI command" marker.
+//
+// Three surfaces name one place — the AI menu's "Getting Started" — so someone
+// who sets this up once and forgets has a way back. See
+// docs/superpowers/specs/2026-08-23-ai-discoverability-design.md.
+// ---------------------------------------------------------------------------
+
+/// Persisted state of the startup nudge. A missing or unparseable file reads as
+/// the default (never shown, never dismissed) — this drives a toast, so a
+/// corrupt file must not be able to break startup.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct NudgeState {
+    pub shown: u32,
+    pub last_shown: u64,
+    pub dismissed: bool,
+}
+
+/// Whether the startup nudge should appear. Pure — every input is passed in, so
+/// each branch is directly testable.
+///
+/// `connected` is the presence of the `ai-connected` marker: once an agent has
+/// actually driven this install, the nudge has nothing left to say.
+pub fn should_nudge(state: &NudgeState, connected: bool, welcome_shown: bool, now: u64) -> bool {
+    if connected || welcome_shown || state.dismissed {
+        return false;
+    }
+    if state.shown >= MAX_NUDGE_SHOWS {
+        return false;
+    }
+    // A never-shown nudge has last_shown == 0, so the subtraction below lets it
+    // through on any real clock without a special case.
+    now.saturating_sub(state.last_shown) >= NUDGE_INTERVAL_SECS
+}
+
+fn read_nudge(base_dir: &Path) -> NudgeState {
+    fs::read_to_string(base_dir.join(NUDGE_FILE))
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn write_nudge(base_dir: &Path, state: &NudgeState) -> Result<(), String> {
+    let json = serde_json::to_string(state).map_err(|e| e.to_string())?;
+    fs::write(base_dir.join(NUDGE_FILE), json).map_err(|e| e.to_string())
+}
+
+fn is_connected(base_dir: &Path) -> bool {
+    base_dir.join(CONNECTED_FILE).exists()
+}
+
+/// Record that an AI command reached this install, and report whether *this*
+/// call is the one that made the transition.
+///
+/// Check-and-set: exactly one call over the lifetime of an install returns
+/// `true`, and that call's command is the one that carries `first_use` to the
+/// frontend. A failure to write is reported as "not the first" so a read-only
+/// data directory produces no toast at all rather than one on every command.
+pub fn mark_connected(version: &str) -> bool {
+    let Ok(base_dir) = paths::app_data_dir() else {
+        return false;
+    };
+    if is_connected(&base_dir) {
+        return false;
+    }
+    match fs::write(base_dir.join(CONNECTED_FILE), version) {
+        Ok(()) => true,
+        Err(e) => {
+            eprintln!("onboarding: failed to write {}: {}", CONNECTED_FILE, e);
+            false
+        }
+    }
+}
+
+/// Whether to raise the startup nudge, counting this launch's show if so.
+/// Called once, by the `main` window, on mount.
+#[tauri::command]
+pub fn ai_nudge_pending() -> bool {
+    let Ok(base_dir) = paths::app_data_dir() else {
+        return false;
+    };
+    let mut state = read_nudge(&base_dir);
+    let now = crate::session::now_secs();
+    if !should_nudge(
+        &state,
+        is_connected(&base_dir),
+        WELCOME_SHOWN_THIS_LAUNCH.load(Ordering::SeqCst),
+        now,
+    ) {
+        return false;
+    }
+    state.shown += 1;
+    state.last_shown = now;
+    if let Err(e) = write_nudge(&base_dir, &state) {
+        // Showing it without recording the show would repeat it every launch.
+        eprintln!("onboarding: failed to write {}: {}", NUDGE_FILE, e);
+        return false;
+    }
+    true
+}
+
+/// Retire the startup nudge permanently — the user either followed it or closed it.
+#[tauri::command]
+pub fn ai_nudge_dismiss() {
+    let Ok(base_dir) = paths::app_data_dir() else {
+        return;
+    };
+    let mut state = read_nudge(&base_dir);
+    if state.dismissed {
+        return;
+    }
+    state.dismissed = true;
+    if let Err(e) = write_nudge(&base_dir, &state) {
+        eprintln!("onboarding: failed to write {}: {}", NUDGE_FILE, e);
+    }
+}
+
+/// Open the "Getting Started" doc. Shared by the AI menu item and the startup
+/// nudge's call to action, so both land on exactly the same document.
+#[tauri::command]
+pub fn ai_open_getting_started(app: AppHandle) {
+    if let Err(e) = open_bundled_doc(&app, "ai-getting-started.md", GETTING_STARTED_MD) {
+        eprintln!("onboarding: {}", e);
+    }
+}
+
+/// Content for the "Getting Started" menu item — static, bundled at compile time.
+pub(crate) fn getting_started_doc() -> &'static str {
+    GETTING_STARTED_MD
 }
 
 /// Content for the "Connect AI via CLI" menu item — composed from
@@ -209,5 +362,140 @@ mod tests {
         let doc = playbook_doc();
         assert!(!doc.is_empty());
         assert!(doc.contains("Spec-driven"));
+    }
+
+    // --- Getting Started doc ------------------------------------------------
+
+    #[test]
+    fn getting_started_doc_maps_the_ai_menu() {
+        let doc = getting_started_doc();
+        assert!(doc.starts_with("# Getting Started with AI in md-mini"));
+        // The menu map is the point of the document; losing it would leave a
+        // setup guide that never says where any of this lives.
+        assert!(doc.contains("## Where this lives"));
+        for item in [
+            "Getting Started",
+            "Connect AI via CLI",
+            "Connect AI via MCP",
+            "Teach your AI md-mini",
+            "AI Playbook",
+        ] {
+            assert!(doc.contains(item), "menu map is missing {:?}", item);
+        }
+        assert!(doc.contains("claude mcp add --scope user mdmini -- mdmini mcp"));
+    }
+
+    #[test]
+    fn welcome_doc_also_points_at_the_ai_menu() {
+        // First-run users only ever see the welcome window, and they are the
+        // ones who set this up once and forget where it was.
+        assert!(WELCOME_MD.contains("## Where this lives"));
+        assert!(WELCOME_MD.contains("Getting Started"));
+    }
+
+    // --- Startup nudge ------------------------------------------------------
+
+    const DAY: u64 = 24 * 60 * 60;
+
+    /// A fresh install, one day into using the app: everything permits a nudge.
+    fn fresh() -> NudgeState {
+        NudgeState::default()
+    }
+
+    #[test]
+    fn nudges_a_fresh_install() {
+        assert!(should_nudge(&fresh(), false, false, DAY));
+    }
+
+    #[test]
+    fn never_nudges_once_an_agent_has_connected() {
+        assert!(!should_nudge(&fresh(), true, false, DAY));
+    }
+
+    #[test]
+    fn never_nudges_on_the_launch_that_showed_the_welcome_window() {
+        assert!(!should_nudge(&fresh(), false, true, DAY));
+    }
+
+    #[test]
+    fn never_nudges_after_dismissal() {
+        let state = NudgeState { shown: 1, last_shown: 0, dismissed: true };
+        assert!(!should_nudge(&state, false, false, 10 * DAY));
+    }
+
+    #[test]
+    fn stops_nudging_after_the_show_limit() {
+        let at_limit = NudgeState {
+            shown: MAX_NUDGE_SHOWS,
+            last_shown: DAY,
+            dismissed: false,
+        };
+        assert!(!should_nudge(&at_limit, false, false, 100 * DAY));
+
+        let below_limit = NudgeState {
+            shown: MAX_NUDGE_SHOWS - 1,
+            last_shown: DAY,
+            dismissed: false,
+        };
+        assert!(should_nudge(&below_limit, false, false, 100 * DAY));
+    }
+
+    #[test]
+    fn holds_off_within_a_day_of_the_last_nudge() {
+        let state = NudgeState { shown: 1, last_shown: 10 * DAY, dismissed: false };
+        // Restarting the app an hour later must not nudge again.
+        assert!(!should_nudge(&state, false, false, 10 * DAY + 3600));
+        // Exactly a day later is the boundary, and it is inclusive.
+        assert!(should_nudge(&state, false, false, 11 * DAY));
+    }
+
+    #[test]
+    fn a_clock_that_went_backwards_does_not_nudge() {
+        // Saturating subtraction: an earlier `now` than `last_shown` yields 0,
+        // which is below the interval, so we simply stay quiet.
+        let state = NudgeState { shown: 1, last_shown: 100 * DAY, dismissed: false };
+        assert!(!should_nudge(&state, false, false, DAY));
+    }
+
+    #[test]
+    fn nudge_state_round_trips_and_tolerates_junk() {
+        let dir = temp_base_dir("nudge");
+
+        // Missing file reads as the default rather than failing.
+        assert_eq!(read_nudge(&dir), NudgeState::default());
+
+        let state = NudgeState { shown: 2, last_shown: 12345, dismissed: true };
+        write_nudge(&dir, &state).expect("write nudge state");
+        assert_eq!(read_nudge(&dir), state);
+
+        // A corrupt file must not be able to break startup either.
+        fs::write(dir.join(NUDGE_FILE), "{not json").expect("write junk");
+        assert_eq!(read_nudge(&dir), NudgeState::default());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn connected_marker_is_a_one_shot() {
+        let dir = temp_base_dir("connected");
+        assert!(!is_connected(&dir));
+
+        // `mark_connected` itself resolves the real app data dir, so exercise
+        // its check-and-set shape against a temp dir here and leave the path
+        // resolution to the caller.
+        assert!(!is_connected(&dir));
+        fs::write(dir.join(CONNECTED_FILE), "1.0.0").expect("write marker");
+        assert!(is_connected(&dir));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_connected_install_never_nudges_regardless_of_counters() {
+        // Whatever the counters say, having connected ends the conversation.
+        for shown in 0..=MAX_NUDGE_SHOWS {
+            let state = NudgeState { shown, last_shown: 0, dismissed: false };
+            assert!(!should_nudge(&state, true, false, 1000 * DAY));
+        }
     }
 }

--- a/src-tauri/welcome.md
+++ b/src-tauri/welcome.md
@@ -2,6 +2,19 @@
 
 md-mini can now be driven by AI agents (Claude Code and others): they can point at places in your open documents, edit them with visible highlights, and ask you questions with buttons right in the document.
 
+## Where this lives
+
+Close this window whenever you like — all of it is permanently in the **AI** menu, in the menu bar:
+
+```
+AI
+├── Getting Started        ← the short version of this document
+├── Connect AI via CLI     ← snippet to paste into CLAUDE.md / AGENTS.md
+├── Connect AI via MCP     ← one command for Claude Code
+├── Teach your AI md-mini  ← how your agent should use it well
+└── AI Playbook            ← what to actually do with it
+```
+
 ## Hook it up — option 1: CLI (zero config)
 
 Run `mdmini agent` and paste the printed block into your agent's instruction file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursor/rules`, `copilot-instructions.md`). Agents with shell access can then use `mdmini show` / `edit` / `ask` directly.

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -352,6 +352,13 @@
    * whichever dispatches second would clobber the first's change instead of
    * building on top of it. */
   async function handleAiCommand(payload: AiCommandPayload): Promise<void> {
+    // Before any of the command's own outcomes: an agent has reached this
+    // install for the first time, and this is the one moment the user is
+    // certain to be looking. Raised even if the command below then fails —
+    // something visibly happened either way, and the point is to explain what.
+    if (payload.firstUse) {
+      toasts.push({ kind: 'ai-first-use' });
+    }
     if (payload.path !== fileState.filePath) {
       await respondToAi(payload.id, { ok: false, error: 'window does not own this file' });
       return;
@@ -719,6 +726,14 @@
       if (count > 0) {
         toasts.push({ kind: 'session', count });
       }
+
+      // Same "launch window only" rule, same reason. Rust owns the whole
+      // decision — whether an agent has ever connected, how often this has
+      // already been shown, and whether the welcome window beat us to it.
+      const nudge = await invoke<boolean>('ai_nudge_pending').catch(() => false);
+      if (nudge) {
+        toasts.push({ kind: 'ai-nudge' });
+      }
     });
 
     const unlistenSessionRestored = onSessionRestored(() => {
@@ -856,6 +871,10 @@
     // Closing the update notice closes it everywhere, not just here.
     if (entry.payload.kind === 'update') {
       invoke('dismiss_update').catch(() => {});
+    }
+    // Closing the AI nudge retires it permanently — it has had its say.
+    if (entry.payload.kind === 'ai-nudge') {
+      invoke('ai_nudge_dismiss').catch(() => {});
     }
   }}
 />

--- a/src/lib/ToastStack.svelte
+++ b/src/lib/ToastStack.svelte
@@ -24,6 +24,18 @@
     copied = true;
     setTimeout(() => { copied = false; }, 1500);
   }
+
+  /**
+   * The nudge's call to action opens the same document the AI menu's first item
+   * opens, then retires itself — following it counts as having been seen.
+   */
+  async function openGettingStarted(entry: ToastEntry): Promise<void> {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('ai_open_getting_started').catch(() => {
+      // Opening a help document is best-effort; never surface a failure here.
+    });
+    dismiss(entry);
+  }
 </script>
 
 {#if store.toasts.length > 0}
@@ -38,12 +50,31 @@
           <button class="md-toast-cmd" title="Click to copy" onclick={copyBrewCommand}>
             {copied ? 'Copied!' : BREW_CMD}
           </button>
-        {:else}
+        {:else if toast.payload.kind === 'session'}
           <span class="md-toast-text">
             <strong>{toast.payload.count}</strong>
             {toast.payload.count === 1 ? 'window' : 'windows'} from your last session
           </span>
           <span class="md-toast-dim">Press <kbd>⇧⌘T</kbd> to reopen</span>
+        {:else if toast.payload.kind === 'ai-nudge'}
+          <!-- The menu is named in the body text, not only on the button: a
+               dismissed toast still delivers the one fact worth keeping. -->
+          <span class="md-toast-text">
+            <strong>Your AI can drive md-mini</strong>
+            <span class="md-toast-dim">— see the <strong>AI</strong> menu</span>
+          </span>
+          <button
+            class="md-toast-cmd md-toast-action"
+            onclick={() => openGettingStarted(toast)}
+          >
+            Getting Started
+          </button>
+        {:else}
+          <span class="md-toast-text">
+            <strong>That was your AI</strong>
+            <span class="md-toast-dim">— md-mini is connected</span>
+          </span>
+          <span class="md-toast-dim">More in the <strong>AI</strong> menu → Getting Started</span>
         {/if}
         <button
           class="md-toast-close"

--- a/src/lib/tauri/events.ts
+++ b/src/lib/tauri/events.ts
@@ -92,6 +92,12 @@ export interface AiCommandPayload {
   /** Adds a free-text input below the option row, in either mode. */
   freeText: boolean;
   timeoutSecs: number;
+  /**
+   * Set on exactly one command per install — the first an agent ever delivers.
+   * Cues the "that was your AI" toast, which is the only surface that reaches
+   * someone whose agent config arrived pre-made from a colleague.
+   */
+  firstUse: boolean;
 }
 
 /**

--- a/src/lib/toasts.svelte.test.ts
+++ b/src/lib/toasts.svelte.test.ts
@@ -54,6 +54,37 @@ describe('createToastStore', () => {
     expect(store.toasts.map((t) => t.payload.kind)).toEqual(['update', 'session']);
   });
 
+  it('AiNoticesSortBelowUpdateAndSession', () => {
+    // Neither AI notice is time-sensitive the way a pending update or a
+    // restorable session is, so they take the bottom of the stack.
+    const store = createToastStore();
+    store.push({ kind: 'ai-nudge' });
+    store.push({ kind: 'session', count: 2 });
+    store.push({ kind: 'update', latest: 'v1.0.0', current: '0.9.0' });
+    expect(store.toasts.map((t) => t.payload.kind)).toEqual([
+      'update',
+      'session',
+      'ai-nudge',
+    ]);
+  });
+
+  it('AiNudge_DismissedById', () => {
+    const store = createToastStore();
+    const id = store.push({ kind: 'ai-nudge' });
+    store.dismiss(id);
+    expect(store.toasts).toEqual([]);
+  });
+
+  it('AiFirstUse_IsItsOwnKind_AndDoesNotReplaceTheNudge', () => {
+    // They never legitimately coexist — one needs a never-connected install,
+    // the other needs a just-connected one — but they are distinct kinds, so
+    // per-kind replacement must not silently swallow one for the other.
+    const store = createToastStore();
+    store.push({ kind: 'ai-nudge' });
+    store.push({ kind: 'ai-first-use' });
+    expect(store.toasts).toHaveLength(2);
+  });
+
   it('OnlyOneToastPerKind', () => {
     // The update checker runs hourly and must not stack duplicates.
     const store = createToastStore();

--- a/src/lib/toasts.svelte.ts
+++ b/src/lib/toasts.svelte.ts
@@ -8,7 +8,11 @@
 
 export type ToastPayload =
   | { kind: 'update'; latest: string; current: string }
-  | { kind: 'session'; count: number };
+  | { kind: 'session'; count: number }
+  /** Startup nudge for someone who has never connected an agent. */
+  | { kind: 'ai-nudge' }
+  /** Raised the first time an agent actually drives this install. */
+  | { kind: 'ai-first-use' };
 
 export type ToastKind = ToastPayload['kind'];
 
@@ -21,6 +25,11 @@ export interface ToastEntry {
 const ORDER: Record<ToastKind, number> = {
   update: 0,
   session: 1,
+  // Both AI notices sort last: neither is time-sensitive the way an update or a
+  // restorable session is. They never coexist — one requires having never
+  // connected, the other requires having just connected.
+  'ai-nudge': 2,
+  'ai-first-use': 2,
 };
 
 export function createToastStore() {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -188,6 +188,14 @@ body {
   opacity: 0.8;
 }
 
+/* A short call to action, not a copyable command: the stack is a flex column,
+   so without this the button stretches the full width of the toast and reads
+   as a mis-sized text field rather than something to click. */
+.md-toast-cmd.md-toast-action {
+  align-self: flex-start;
+  padding: 5px 12px;
+}
+
 .md-toast-close {
   position: absolute;
   top: 8px;


### PR DESCRIPTION
Users report not knowing the AI interface exists. Both surfaces we shipped with 1.0 are one-shot: the welcome window opens once per version and is then unrecoverable, and the AI menu only helps someone who already suspects it's there. The follow-on problem matters more — set it up once, forget, need it again a month later, and there's no way back.

Three surfaces now name **one** place — the AI menu's **Getting Started** — so what gets remembered is the name, not any single document.

## What's new

| Surface | Behavior |
|---|---|
| Startup toast | `main` window only, while no agent has ever connected. At most 3 shows, at most once a day, silent on a launch that already opened the welcome window. Following or closing it retires it permanently. |
| `Getting Started` doc | Opened by the toast's CTA and by a new first item in the AI menu — the same document either way. Its lead block is a **map of the AI menu**, not setup instructions. |
| First-use toast | Fires on the first AI command an install ever handles — the only surface that reaches users whose agent config arrived pre-made from a colleague. |

`welcome.md` gains the same menu map: first-run users are exactly the ones who later forget where this lives.

## Implementation notes

Writing the `ai-connected` marker and raising the first-use toast are **one check-and-set**, in `dispatch`, after validation but before routing — a rejected request must not burn the one notification. The result rides `AiCommandPayload.first_use` rather than a separate event, so a command drained from `AiQueue` by a window that didn't exist yet carries it too.

Nudge state lives in `ai-nudge.json` next to `onboarding-version`, so a dev build is naturally isolated from a release install. A missing or corrupt file reads as defaults — this drives a toast and must never break startup.

## Verification

- `cargo test` — 124 passed (14 new, covering every `should_nudge` branch, state round-trip, corrupt-file tolerance, and clock-went-backwards)
- `npx vitest run --dir src` — 531 passed (3 new)
- `npm run check` — 0 errors
- `cargo clippy` — no new warnings
- Manually verified end-to-end in an isolated `npm run dev:app`: nudge appears and sorts below the session toast, CTA opens the doc and persists `dismissed: true`, a real `mdmini ai show` over the dev socket raises the first-use toast and writes the marker.

Design: `docs/superpowers/specs/2026-08-23-ai-discoverability-design.md`

## Not included

No persistent corner badge, no empty-state block, no running `claude mcp add` for the user, no telemetry, and no revival of a dismissed nudge on version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
