### PR TITLE
fix(build): support Intel Macs via a universal binary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ Minimalist live-preview markdown editor for macOS. Tauri 2 + Svelte 5 + CodeMirr
 | `cd src-tauri && cargo test` | Run Rust tests |
 | `cargo clippy --manifest-path src-tauri/Cargo.toml` | Rust linter |
 | `npm run build:dev` | **Renamed dev .dmg** (`md-mini-dev`). Safe to install alongside production. |
+| `npm run check:x86` | Compile for `x86_64-apple-darwin`. Fast guard that an Intel build still works — no bundle, no install. |
+| `npm run build:universal` | **Production universal .dmg** (Apple Silicon + Intel). Same owner-triggered rule as `tauri build`. |
 | `npm run tauri build` | **Production build (creates .dmg).** Replaces the user's installed md-mini if installed. **Explicit, owner-triggered only — do NOT run as part of routine dev/QA.** |
 | `npm run tauri dev` | Tauri dev with **production identifier**. Conflicts with running production md-mini (shares single-instance socket, app data, recovery files). **Avoid while the user is actively using md-mini — use `npm run dev` or `npm run dev:app` instead.** |
 | `npm run build` | Frontend build only (no Tauri bundle) |
@@ -138,6 +140,7 @@ src/                    # Frontend (Svelte + TypeScript)
 
 ## Gotchas
 
+- **Never pass a `bool` literal to an Objective-C API.** `objc`'s `BOOL` is `bool` on aarch64 but `c_schar` (`i8`) on every other target, so `ns_app.activateIgnoringOtherApps_(true)` compiles on Apple Silicon and fails the x86_64 build with `expected i8, found bool`. Use `cocoa::base::YES`/`NO`, which are defined per arch. This kept Intel builds broken until 2026-08-23 and is invisible unless you actually cross-compile — `npm run check:x86` is the guard.
 - **Svelte 5 runes require `.svelte.ts` extension:** Files using `$state`, `$derived`, `$effect` outside `.svelte` components MUST be named `*.svelte.ts`, not `*.ts`. Plain `.ts` files won't compile runes — the app loads a white screen with no errors. `npm run check` does NOT catch this.
 - **Kill port 1420 before `npm run tauri dev`:** Previous dev sessions leave Vite running. Use `lsof -ti:1420 | xargs kill -9` to free the port.
 - **GFM required:** `@lezer/markdown` needs explicit `extensions: [Strikethrough, Table]` in the markdown() call — without this, `~~strikethrough~~` and tables don't produce AST nodes

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,5 +1,31 @@
 # md-mini Distribution Guide
 
+> **Статус документа.** Разделы 1 и 4 описывают то, как релиз работает сейчас.
+> Разделы 2 и 3 (Tauri Updater, GitHub Actions matrix) — нереализованный план
+> времён 0.2.0: релизного CI в репозитории нет, `.github/workflows/` содержит
+> только `deploy-site.yml`, а сборка идёт локально на машине владельца через
+> скилл `/brew-release`. Не читать их как описание текущего процесса.
+
+## Архитектуры
+
+Один **universal** `.dmg` на обе архитектуры — Apple Silicon и Intel. Собирается
+`npm run build:universal` (`tauri build --target universal-apple-darwin`); нужны
+оба rustup-таргета:
+
+```bash
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+```
+
+Universal выбран вместо двух отдельных `.dmg` потому, что он *упрощает* cask:
+один URL и один `sha256` вместо ветки по `Hardware::CPU.arm?` с двумя хэшами.
+Расплата за это меньше, чем кажется — `lipo` склеивает только исполняемый файл,
+а ресурсы и шрифты не дублируются, так что universal-сборка примерно в полтора
+раза больше arm64-only, а не вдвое.
+
+Проверить, что x86_64 вообще собирается, не гоняя весь бандл:
+`npm run check:x86`. Тесты под Intel-архитектурой (идут через Rosetta):
+`cargo test --manifest-path src-tauri/Cargo.toml --target x86_64-apple-darwin`.
+
 ## 1. Homebrew Tap (установка для юзеров)
 
 Users install with:
@@ -17,13 +43,10 @@ brew tap USERNAME/md-mini && brew install --cask md-mini
 cask "md-mini" do
   version "0.1.0"
 
-  if Hardware::CPU.arm?
-    url "https://github.com/USERNAME/md-mini/releases/download/v#{version}/md-mini_#{version}_aarch64.dmg"
-    sha256 "REPLACE_WITH_AARCH64_SHA256"
-  else
-    url "https://github.com/USERNAME/md-mini/releases/download/v#{version}/md-mini_#{version}_x64.dmg"
-    sha256 "REPLACE_WITH_X64_SHA256"
-  end
+  # Universal build — no `Hardware::CPU.arm?` branch and no
+  # `depends_on arch:`, both architectures take this same file.
+  url "https://github.com/USERNAME/md-mini/releases/download/v#{version}/md-mini_#{version}_universal.dmg"
+  sha256 "REPLACE_WITH_UNIVERSAL_SHA256"
 
   name "md-mini"
   desc "Minimalist live-preview markdown editor for macOS"
@@ -203,6 +226,9 @@ jobs:
 
 ## 4. Release Checklist
 
+Реальный процесс — локальная сборка, не CI. Обычно его прогоняет скилл
+`/brew-release`; ниже то, что он делает, для случая «руками».
+
 ```bash
 # 1. Bump version
 vim src-tauri/tauri.conf.json package.json  # change "version"
@@ -211,16 +237,26 @@ vim src-tauri/tauri.conf.json package.json  # change "version"
 git add -A && git commit -m "chore: bump to 0.2.0"
 git tag v0.2.0 && git push origin main --tags
 
-# 3. Wait ~15 min for GitHub Action
+# 3. Build the universal .dmg locally (owner-triggered — replaces the
+#    installed md-mini if you then install it)
+npm run build:universal
+# → src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
 
-# 4. Update Homebrew cask (get SHA256 from release DMGs)
-curl -L -o /tmp/arm.dmg "https://github.com/USER/md-mini/releases/download/v0.2.0/md-mini_0.2.0_aarch64.dmg"
-shasum -a 256 /tmp/arm.dmg
-# Update homebrew-md-mini/Casks/md-mini.rb → version + sha256
+# 4. Publish, naming the asset so the cask URL matches
+gh release create v0.2.0 --title v0.2.0 --notes "..." \
+  "src-tauri/target/universal-apple-darwin/release/bundle/dmg/md-mini_0.2.0_universal.dmg"
 
-# 5. Verify
-brew upgrade --cask md-mini && mdmini
+# 5. Update the Homebrew cask — one sha256, no per-arch branch
+shasum -a 256 src-tauri/target/universal-apple-darwin/release/bundle/dmg/md-mini_0.2.0_universal.dmg
+# malinborn/homebrew-mdmini → Casks/mdmini.rb: version + sha256 + url
+
+# 6. Verify
+brew update && brew upgrade --cask mdmini && mdmini
 ```
+
+Проверить на Intel без Intel-мака нельзя целиком, но `arch -x86_64` запустит
+собранный universal `.app` под Rosetta на Apple Silicon — этого достаточно,
+чтобы поймать «не тот слайс» и падение на старте.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "test": "vitest",
     "tauri": "tauri",
     "dev:app": "tauri dev --config src-tauri/tauri.dev.conf.json",
-    "build:dev": "tauri build --config src-tauri/tauri.dev.conf.json"
+    "build:dev": "tauri build --config src-tauri/tauri.dev.conf.json",
+    "build:universal": "tauri build --target universal-apple-darwin",
+    "check:x86": "cargo build --manifest-path src-tauri/Cargo.toml --target x86_64-apple-darwin"
   },
   "license": "GPL-3.0-only",
   "dependencies": {

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -107,7 +107,10 @@ pub fn open_file_window(app: &AppHandle, path: Option<String>) {
             unsafe {
                 use cocoa::appkit::{NSApplication, NSApplicationActivationPolicy};
                 let ns_app = cocoa::appkit::NSApp();
-                ns_app.activateIgnoringOtherApps_(true);
+                // `cocoa::base::YES`, never a `true` literal: Objective-C's BOOL
+                // is `bool` on aarch64 but `i8` everywhere else, so a literal
+                // type-checks on Apple Silicon and fails to compile for x86_64.
+                ns_app.activateIgnoringOtherApps_(cocoa::base::YES);
             }
             // Track the file path in OpenFiles and store it in PendingFiles
             // so the frontend can pull it on mount via get_pending_file command.
@@ -282,7 +285,8 @@ pub fn open_restored_window(app: &AppHandle, snapshot: &crate::session::WindowSn
             unsafe {
                 use cocoa::appkit::NSApplication;
                 let ns_app = cocoa::appkit::NSApp();
-                ns_app.activateIgnoringOtherApps_(true);
+                // See the note on the other call site: BOOL is arch-dependent.
+                ns_app.activateIgnoringOtherApps_(cocoa::base::YES);
             }
 
             let pending = app.state::<PendingFiles>();


### PR DESCRIPTION
md-mini shipped arm64-only. On an Intel Mac `brew install --cask mdmini` refused before downloading anything, with no explanation — neither the README nor the site ever claimed Apple Silicon only.

Three separate things caused that. This PR fixes the one that lives in this repo.

## The code blocker

`cargo build --target x86_64-apple-darwin` failed with exactly two `E0308` errors, both `activateIgnoringOtherApps_(true)` in `src-tauri/src/window.rs`.

`objc`'s `BOOL` is `bool` on aarch64 but `c_schar` (`i8`) on every other target, so a `true` literal type-checks **only** on Apple Silicon. The fix is `cocoa::base::YES`, which is defined per arch. These two were the only Objective-C call sites in the project — audited, not assumed.

## Why universal rather than two .dmg files

It *simplifies* the cask instead of complicating it: one URL and one `sha256`, no `Hardware::CPU.arm?` branch and no `depends_on arch:`. `lipo` merges only the executable — resources and bundled fonts are not duplicated — so the current 7 MB arm64 build grows to roughly 11 MB, not 14.

## Also in here

- `npm run build:universal` — `tauri build --target universal-apple-darwin`
- `npm run check:x86` — cheap guard that an Intel build still compiles. This class of breakage is invisible unless you actually cross-compile, which is exactly how it survived to 1.0.
- `docs/distribution.md` — the release checklist now matches reality (local universal build), and sections 2–3 are flagged as an unexecuted 0.2.0-era plan. There is no release CI; the doc previously implied there was.
- `CLAUDE.md` — the `BOOL` trap, so the next `expected i8, found bool` is recognized rather than rediscovered.

## Verification

- `x86_64` target produces a real `Mach-O 64-bit executable x86_64`
- 112 Rust tests pass under `--target x86_64-apple-darwin` (Rosetta) as well as natively on arm64
- `cargo clippy` clean for both targets; 528 frontend tests unaffected

## Not included — required to actually ship Intel support

1. Build and publish the universal `.dmg` (owner-triggered; `npm run build:universal`)
2. In `malinborn/homebrew-mdmini` → `Casks/mdmini.rb`: drop `depends_on arch: :arm64`, drop `_aarch64` from the URL, update `sha256`

Until step 2 lands, Intel users still can't install — this PR makes that possible, it does not complete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
